### PR TITLE
Limit ObjectMessage deserialization with a package white list

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,13 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for an overview of the development proc
 
 ### Integration Tests
 
-TBD: open sourcing the compliance test suite is a work-in-progress.
+Assuming a node with [rabbitmq-jms-topic-exchange](https://github.com/rabbitmq/rabbitmq-jms-topic-exchange/) is running on localhost
+with all defaults:
+
+    mvn clean verify
+
+The easiest way to run a test node is to clone
+[rabbitmq-jms-topic-exchange](https://github.com/rabbitmq/rabbitmq-jms-topic-exchange/) and use `make run-broker`.
 
 
 ## License and Copyright

--- a/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
@@ -96,6 +96,7 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
         com.rabbitmq.client.Connection rabbitConnection = getRabbitConnection(factory);
 
         RMQConnection conn = new RMQConnection(rabbitConnection, getTerminationTimeout(), getQueueBrowserReadMax());
+        conn.setTrustedPackages(this.trustedPackages);
         logger.debug("Connection {} created.", conn);
         return conn;
     }

--- a/src/main/java/com/rabbitmq/jms/admin/RMQDestination.java
+++ b/src/main/java/com/rabbitmq/jms/admin/RMQDestination.java
@@ -142,12 +142,16 @@ public class RMQDestination implements Queue, Topic, Destination, Referenceable,
     }
 
     /**
-     * @return <code>true</code> if this is an AMQP mapped resource, <code>false</code> otherwise
+     * @return <code>true</code> if this is an AMQP 0-9-1 mapped resource, <code>false</code> otherwise
      */
     public boolean isAmqp() {
         return this.amqp;
     }
-    /** For JNDI binding and Spring beans */
+
+    /**
+     * For JNDI binding and Spring beans
+     * @param amqp set to <code>true</code> if this is an AMQP 0-9-1 mapped resource, <code>false</code> otherwise
+     */
     public void setAmqp(boolean amqp) {
         if (this.isDeclared())
             throw new IllegalStateException();
@@ -158,7 +162,10 @@ public class RMQDestination implements Queue, Topic, Destination, Referenceable,
     public String getAmqpQueueName() {
         return this.amqpQueueName;
     }
-    /** For JNDI binding and Spring beans */
+    /**
+     * For JNDI binding and Spring beans
+     * @param amqpQueueName AMQP 0-9-1 queue name
+     */
     public void setAmqpQueueName(String amqpQueueName) {
         if (this.isDeclared())
             throw new IllegalStateException();
@@ -167,7 +174,10 @@ public class RMQDestination implements Queue, Topic, Destination, Referenceable,
     public String getAmqpExchangeName() {
         return this.amqpExchangeName;
     }
-    /** For JNDI binding and Spring beans */
+    /**
+     * For JNDI binding and Spring beans
+     * @param amqpExchangeName AMQP 0-9-1 exchange name to use
+     */
     public void setAmqpExchangeName(String amqpExchangeName) {
         if (this.isDeclared())
             throw new IllegalStateException();
@@ -176,23 +186,36 @@ public class RMQDestination implements Queue, Topic, Destination, Referenceable,
     public String getDestinationName() {
         return this.destinationName;
     }
-    /** For JNDI binding and Spring beans */
+    /**
+     * For JNDI binding and Spring beans
+     * @param destinationName JMS destination name
+     */
     public void setDestinationName(String destinationName) {
         if (isDeclared())
             throw new IllegalStateException();
         this.destinationName = destinationName;
     }
+
+    /**
+     * @return AMQP 0-9-1 routing key
+     */
     public String getAmqpRoutingKey() {
         return this.amqpRoutingKey;
     }
-    /** For JNDI binding and Spring beans */
+    /**
+     * For JNDI binding and Spring beans
+     * @param routingKey AMQP 0-9-1 routing key
+     */
     public void setAmqpRoutingKey(String routingKey) {
         if (isDeclared())
             throw new IllegalStateException();
         this.amqpRoutingKey = routingKey;
     }
 
-    /** Internal use only */
+    /**
+     * Internal use only
+     * @return AMQP 0-9-1 exchange type used
+     */
     public String amqpExchangeType() {
         return queueOrTopicExchangeType(this.isQueue);
     }

--- a/src/main/java/com/rabbitmq/jms/client/Completion.java
+++ b/src/main/java/com/rabbitmq/jms/client/Completion.java
@@ -22,6 +22,7 @@ public class Completion {
 
     /**
      * Non-blocking snapshot test for completion.
+     * @return <code>true</code> if this operation has completed, <code>false</code> otherwise
      */
     public boolean isComplete() {
         return this.fb.isComplete();

--- a/src/main/java/com/rabbitmq/jms/client/DeliveryExecutor.java
+++ b/src/main/java/com/rabbitmq/jms/client/DeliveryExecutor.java
@@ -53,7 +53,9 @@ public class DeliveryExecutor {
      * only one <code>onMessage</code> call being executed at any one time.
      *
      * @param rmqMessage the message to deliver
+     * @param messageListener JMS message listener that will handle the delivery
      * @throws JMSException if the delivery takes too long and is aborted
+     * @throws InterruptedException if executing thread is interrupted
      */
     public void deliverMessageWithProtection(RMQMessage rmqMessage, MessageListener messageListener) throws JMSException, InterruptedException {
         try {

--- a/src/main/java/com/rabbitmq/jms/client/RMQConnection.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQConnection.java
@@ -27,6 +27,7 @@ import javax.jms.Topic;
 import javax.jms.TopicConnection;
 import javax.jms.TopicSession;
 
+import com.rabbitmq.jms.util.WhiteListObjectInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,6 +79,13 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
     private volatile boolean canSetClientID = true;
 
     /**
+     * Classes in these packages can be transferred via ObjectMessage.
+     *
+     * @see WhiteListObjectInputStream
+     */
+    private List<String> trustedPackages = WhiteListObjectInputStream.DEFAULT_TRUSTED_PACKAGES;
+
+    /**
      * Creates an RMQConnection object.
      * @param rabbitConnection the TCP connection wrapper to the RabbitMQ broker
      * @param terminationTimeout timeout for close in milliseconds
@@ -113,6 +121,7 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
         illegalStateExceptionIfClosed();
         freezeClientID();
         RMQSession session = new RMQSession(this, transacted, acknowledgeMode, this.subscriptions);
+        session.setTrustedPackages(this.trustedPackages);
         this.sessions.add(session);
         return session;
     }
@@ -152,6 +161,19 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
             throw new IllegalStateException("Client ID already set.");
         }
 
+    }
+
+    public List<String> getTrustedPackages() {
+        return trustedPackages;
+    }
+
+    /**
+     * @param value list of trusted package prefixes
+     *
+     * @see com.rabbitmq.jms.admin.RMQConnectionFactory#setTrustedPackages(List)
+     */
+    public void setTrustedPackages(List<String> value) {
+        this.trustedPackages = value;
     }
 
     /**

--- a/src/main/java/com/rabbitmq/jms/client/RMQMessageProducer.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQMessageProducer.java
@@ -227,7 +227,7 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
             deliveryMode = javax.jms.DeliveryMode.NON_PERSISTENT;
 
         /* Normalise message to internal form */
-        RMQMessage rmqMessage = RMQMessage.normalise(message);
+        RMQMessage rmqMessage = RMQMessage.normalise(message, session.getTrustedPackages());
 
         /* Set known JMS message properties that need to be set during this call */
         long currentTime = System.currentTimeMillis();

--- a/src/main/java/com/rabbitmq/jms/client/RMQMessageProducer.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQMessageProducer.java
@@ -2,6 +2,7 @@
 package com.rabbitmq.jms.client;
 
 import java.io.IOException;
+import java.util.List;
 
 import javax.jms.Destination;
 import javax.jms.InvalidDestinationException;
@@ -62,6 +63,7 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
      * The default TTL value is 0 (zero), meaning indefinite (no time-out).
      */
     private long ttl = Message.DEFAULT_TIME_TO_LIVE;
+    private List<String> trustedPackages;
 
     /**
      * Create a producer of messages.
@@ -71,6 +73,8 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
     public RMQMessageProducer(RMQSession session, RMQDestination destination) {
         this.session = session;
         this.destination = destination;
+
+        this.trustedPackages = session.getTrustedPackages();
     }
 
     /**
@@ -227,7 +231,7 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
             deliveryMode = javax.jms.DeliveryMode.NON_PERSISTENT;
 
         /* Normalise message to internal form */
-        RMQMessage rmqMessage = RMQMessage.normalise(message, session.getTrustedPackages());
+        RMQMessage rmqMessage = RMQMessage.normalise(message, this.trustedPackages);
 
         /* Set known JMS message properties that need to be set during this call */
         long currentTime = System.currentTimeMillis();

--- a/src/main/java/com/rabbitmq/jms/client/RMQSession.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQSession.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
@@ -39,6 +40,7 @@ import javax.jms.TopicPublisher;
 import javax.jms.TopicSession;
 import javax.jms.TopicSubscriber;
 
+import com.rabbitmq.jms.util.WhiteListObjectInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -147,6 +149,13 @@ public class RMQSession implements Session, QueueSession, TopicSession {
     /** The channels we use for browsing queues (there may be more than one in operation at a time) */
     private Set<Channel> browsingChannels = new HashSet<Channel>(); // @GuardedBy(bcLock)
     private final Object bcLock = new Object();
+
+    /**
+     * Classes in these packages can be transferred via ObjectMessage.
+     *
+     * @see WhiteListObjectInputStream
+     */
+    private List<String> trustedPackages = WhiteListObjectInputStream.DEFAULT_TRUSTED_PACKAGES;
 
     /**
      * Creates a session object associated with a connection
@@ -283,6 +292,15 @@ public class RMQSession implements Session, QueueSession, TopicSession {
     public int getAcknowledgeMode() throws JMSException {
         illegalStateExceptionIfClosed();
         return getAcknowledgeModeNoException();
+    }
+
+    @SuppressWarnings("unused")
+    public List<String> getTrustedPackages() {
+        return trustedPackages;
+    }
+
+    public void setTrustedPackages(List<String> trustedPackages) {
+        this.trustedPackages = trustedPackages;
     }
 
     /**

--- a/src/main/java/com/rabbitmq/jms/client/message/RMQObjectMessage.java
+++ b/src/main/java/com/rabbitmq/jms/client/message/RMQObjectMessage.java
@@ -9,6 +9,8 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
 
 import javax.jms.JMSException;
 import javax.jms.MessageNotWriteableException;
@@ -16,14 +18,24 @@ import javax.jms.ObjectMessage;
 
 import com.rabbitmq.jms.client.RMQMessage;
 import com.rabbitmq.jms.util.RMQJMSException;
+import com.rabbitmq.jms.util.WhiteListObjectInputStream;
 
 /**
  * Implements {@link ObjectMessage} interface.
  */
 public class RMQObjectMessage extends RMQMessage implements ObjectMessage {
 
+    private final List<String> trustedPackages;
     /** Buffer to hold serialised object */
     private volatile byte[] buf = null;
+
+    public RMQObjectMessage() {
+        this(WhiteListObjectInputStream.DEFAULT_TRUSTED_PACKAGES);
+    }
+
+    public RMQObjectMessage(List<String> trustedPackages) {
+        this.trustedPackages = trustedPackages;
+    }
 
     @Override
     public void setObject(Serializable object) throws JMSException {
@@ -49,17 +61,21 @@ public class RMQObjectMessage extends RMQMessage implements ObjectMessage {
 
     @Override
     public Serializable getObject() throws JMSException {
-        if (buf==null) {
+        return this.getObject(this.trustedPackages);
+    }
+
+    public Serializable getObject(List<String> trustedPackages) throws JMSException {
+        if (buf == null) {
             return null;
         } else {
             this.loggerDebugByteArray("Deserialising object from buffer {} for {}", this.buf, "RMQObjectMessage");
             ByteArrayInputStream bin = new ByteArrayInputStream(buf);
             try {
-                ObjectInputStream in = new ObjectInputStream(bin);
+                WhiteListObjectInputStream in = new WhiteListObjectInputStream(bin, trustedPackages);
                 return (Serializable)in.readObject();
-            }catch (ClassNotFoundException x) {
+            } catch (ClassNotFoundException x) {
                 throw new RMQJMSException(x);
-            }catch (IOException x) {
+            } catch (IOException x) {
                 throw new RMQJMSException(x);
             }
         }
@@ -114,7 +130,19 @@ public class RMQObjectMessage extends RMQMessage implements ObjectMessage {
         RMQObjectMessage rmqOMsg = new RMQObjectMessage();
         RMQMessage.copyAttributes(rmqOMsg, msg);
 
+        // note: ObjectMessage here comes from the outside and may
+        //       be an implementation not provided by us, so we cannot
+        //       enforce class name validation.
         rmqOMsg.setObject(msg.getObject());
+
+        return rmqOMsg;
+    }
+
+    public static RMQMessage recreate(RMQObjectMessage msg, List<String> patterns) throws JMSException {
+        RMQObjectMessage rmqOMsg = new RMQObjectMessage(patterns);
+        RMQMessage.copyAttributes(rmqOMsg, msg);
+
+        rmqOMsg.setObject(msg.getObject(patterns));
 
         return rmqOMsg;
     }

--- a/src/main/java/com/rabbitmq/jms/parse/ParseTree.java
+++ b/src/main/java/com/rabbitmq/jms/parse/ParseTree.java
@@ -22,8 +22,7 @@ package com.rabbitmq.jms.parse;
 public interface ParseTree<Node> {
 
     /**
-     * The node at the root of the tree.
-     * @return
+     * @return the node at the root of the tree.
      */
     Node getNode();
 

--- a/src/main/java/com/rabbitmq/jms/util/WhiteListObjectInputStream.java
+++ b/src/main/java/com/rabbitmq/jms/util/WhiteListObjectInputStream.java
@@ -221,9 +221,9 @@ public class WhiteListObjectInputStream extends ObjectInputStream {
             }
 
             if (!result) {
-                throw new ClassNotFoundException(
-                                                        "Class " + clazz + " is not trusted to be serialized as ObjectMessage payload. "
-                                                                + "Trusted packages can be configured via RMQConnectionFactory.");
+                throw new ClassNotFoundException("Class " + clazz + " is not trusted to be deserialized as ObjectMessage payload. "
+                                                 + "Trusted packages can be configured via -Dcom.rabbitmq.jms.TrustedPackagesPrefixes "
+                                                 + " or RMQConnectionFactory#setTrustedPackages.");
             }
         }
     }

--- a/src/main/java/com/rabbitmq/jms/util/WhiteListObjectInputStream.java
+++ b/src/main/java/com/rabbitmq/jms/util/WhiteListObjectInputStream.java
@@ -1,0 +1,242 @@
+/* Copyright (c) 2013 Pivotal Software, Inc. All rights reserved. */
+package com.rabbitmq.jms.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamClass;
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * <p>
+ * An {@link ObjectInputStream} implementation that checks loaded classes
+ * against a list of trusted packages or package prefixes.
+ * </p>
+ * <p>
+ * Heavily inspired by and derived from
+ * org.apache.activemq.util.ClassLoadingAwareObjectInputStream in ActiveMQ
+ * as well as https://github.com/spring-projects/spring-amqp/commit/4150f107e60cac4a7735fcf7cb4c1889a0cbab6c.
+ * </p>
+ *
+ * @see ObjectInputStream
+ */
+public class WhiteListObjectInputStream extends ObjectInputStream {
+    private static final ClassLoader FALLBACK_CLASS_LOADER =
+            WhiteListObjectInputStream.class.getClassLoader();
+
+    public static final List<String> DEFAULT_TRUSTED_PACKAGES;
+
+    static {
+        // backwards compatible default
+        String viaProperty = System.getProperty("com.rabbitmq.jms.TrustedPackagesPrefixes", "*");
+        DEFAULT_TRUSTED_PACKAGES = Arrays.asList(viaProperty.split(","));
+    }
+
+    private final ClassLoader inputStreamLoader;
+    private List<String> trustedPackages = WhiteListObjectInputStream.DEFAULT_TRUSTED_PACKAGES;
+
+    /**
+     * <p>
+     * Creates an ObjectInputStream that reads from the specified InputStream.
+     * A serialization stream header is read from the stream and verified.
+     * This constructor will block until the corresponding ObjectOutputStream
+     * has written and flushed the header.
+     * </p>
+     * <p>If a security manager is installed, this constructor will check for
+     * the "enableSubclassImplementation" SerializablePermission when invoked
+     * directly or indirectly by the constructor of a subclass which overrides
+     * the ObjectInputStream.readFields or ObjectInputStream.readUnshared
+     * methods.
+     * </p>
+     *
+     * @param in input stream to read from
+     * @throws IOException          if an I/O error occurs while reading stream header
+     * @throws SecurityException    if untrusted subclass illegally overrides
+     *                              security-sensitive methods
+     * @throws NullPointerException if <code>in</code> is <code>null</code>
+     * @see ObjectInputStream#ObjectInputStream()
+     * @see ObjectInputStream#readFields()
+     */
+    public WhiteListObjectInputStream(InputStream in) throws IOException {
+        super(in);
+        this.inputStreamLoader = in.getClass().getClassLoader();
+    }
+
+    /**
+     * <p>Creates an ObjectInputStream that reads from the specified InputStream.
+     * A serialization stream header is read from the stream and verified.
+     * This constructor will block until the corresponding ObjectOutputStream
+     * has written and flushed the header.
+     * </p>
+     * <p>If a security manager is installed, this constructor will check for
+     * the "enableSubclassImplementation" SerializablePermission when invoked
+     * directly or indirectly by the constructor of a subclass which overrides
+     * the ObjectInputStream.readFields or ObjectInputStream.readUnshared
+     * methods.
+     * </p>
+     * @param in              input stream to read from
+     * @param trustedPackages List of packages that are trusted. Classes in them
+     *                        will be serialized.
+     * @throws IOException          if an I/O error occurs while reading stream header
+     * @throws SecurityException    if untrusted subclass illegally overrides
+     *                              security-sensitive methods
+     * @throws NullPointerException if <code>in</code> is <code>null</code>
+     * @see ObjectInputStream#ObjectInputStream()
+     * @see ObjectInputStream#readFields()
+     */
+    public WhiteListObjectInputStream(InputStream in, List<String> trustedPackages) throws IOException {
+        super(in);
+        this.inputStreamLoader = in.getClass().getClassLoader();
+        this.trustedPackages = trustedPackages;
+    }
+
+    /**
+     * Load the local class equivalent of the specified stream class
+     * description.  Subclasses may implement this method to allow classes to
+     * be fetched from an alternate source.
+     * <p>The corresponding method in <code>ObjectOutputStream</code> is
+     * <code>annotateClass</code>.  This method will be invoked only once for
+     * each unique class in the stream.  This method can be implemented by
+     * subclasses to use an alternate loading mechanism but must return a
+     * <code>Class</code> object. Once returned, if the class is not an array
+     * class, its serialVersionUID is compared to the serialVersionUID of the
+     * serialized class, and if there is a mismatch, the deserialization fails
+     * and an exception is thrown.
+     * </p>
+     * <p>The default implementation of this method in
+     * <code>ObjectInputStream</code> returns the result of calling
+     * <pre>
+     *     Class.forName(desc.getName(), false, loader)
+     * </pre>
+     * where <code>loader</code> is determined as follows: if there is a
+     * method on the current thread's stack whose declaring class was
+     * defined by a user-defined class loader (and was not a generated to
+     * implement reflective invocations), then <code>loader</code> is class
+     * loader corresponding to the closest such method to the currently
+     * executing frame; otherwise, <code>loader</code> is
+     * <code>null</code>. If this call results in a
+     * <code>ClassNotFoundException</code> and the name of the passed
+     * <code>ObjectStreamClass</code> instance is the Java language keyword
+     * for a primitive type or void, then the <code>Class</code> object
+     * representing that primitive type or void will be returned
+     * (e.g., an <code>ObjectStreamClass</code> with the name
+     * <code>"int"</code> will be resolved to <code>Integer.TYPE</code>).
+     * Otherwise, the <code>ClassNotFoundException</code> will be thrown to
+     * the caller of this method.
+     *
+     * @param desc an instance of class <code>ObjectStreamClass</code>
+     * @return a <code>Class</code> object corresponding to <code>desc</code>
+     * @throws IOException            any of the usual Input/Output exceptions.
+     * @throws ClassNotFoundException if class of a serialized object cannot
+     *                                be found or isn't trusted.
+     */
+    @Override
+    protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+        ClassLoader threadLoader = Thread.currentThread().getContextClassLoader();
+        Class clazz = load(desc.getName(), threadLoader, inputStreamLoader);
+        checkWhiteList(clazz);
+        return clazz;
+    }
+
+    @Override
+    protected Class<?> resolveProxyClass(String[] interfaces) throws IOException, ClassNotFoundException {
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        Class[] ifaces = new Class[interfaces.length];
+        for (int i = 0; i < interfaces.length; i++) {
+            ifaces[i] = load(interfaces[i], cl);
+        }
+
+        Class clazz = null;
+        try {
+            clazz = Proxy.getProxyClass(cl, ifaces);
+        } catch (IllegalArgumentException e) {
+            try {
+                clazz = Proxy.getProxyClass(inputStreamLoader, ifaces);
+            } catch (IllegalArgumentException _ignored1) {
+                // ignore
+            }
+            try {
+                clazz = Proxy.getProxyClass(FALLBACK_CLASS_LOADER, ifaces);
+            } catch (IllegalArgumentException _ignored2) {
+                // ignore
+            }
+        }
+
+        if (clazz != null) {
+            checkWhiteList(clazz);
+            return clazz;
+        } else {
+            throw new ClassNotFoundException(null);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    public void addTrustedPackage(String trustedPackage) {
+        this.trustedPackages.add(trustedPackage);
+    }
+
+    /**
+     * @return list of packages trusted for deserialization
+     * from ObjectMessage payloads
+     */
+    @SuppressWarnings("unused")
+    public List<String> getTrustedPackages() {
+        return trustedPackages;
+    }
+
+    /**
+     * @param trustedPackages list of packages trusted for deserialization
+     *                        from ObjectMessage payloads
+     */
+    @SuppressWarnings("unused")
+    public void setTrustedPackages(List<String> trustedPackages) {
+        this.trustedPackages = trustedPackages;
+    }
+
+    /**
+     * @return true if this object stream considers all packages to
+     * be trusted, false otherwise
+     */
+    public boolean shouldTrustAllPackages() {
+        return (this.trustedPackages != null) && (trustedPackages.size() == 1 && trustedPackages.get(0).equals("*"));
+    }
+
+    private void checkWhiteList(Class clazz) throws ClassNotFoundException {
+        if (clazz.isPrimitive()) {
+            return;
+        }
+
+        if (clazz.getPackage() != null && !shouldTrustAllPackages()) {
+            boolean result = false;
+            String p = clazz.getPackage().getName();
+            for (String pkg : this.trustedPackages) {
+                // Note: this means that an empty string works the same way as "*"
+                //       but making it mean "trust no package" makes even less sense
+                if (p.equals(pkg) || p.startsWith(pkg)) {
+                    result = true;
+                    break;
+                }
+            }
+
+            if (!result) {
+                throw new ClassNotFoundException(
+                                                        "Class " + clazz + " is not trusted to be serialized as ObjectMessage payload. "
+                                                                + "Trusted packages can be configured via RMQConnectionFactory.");
+            }
+        }
+    }
+
+    private Class<?> load(String className, ClassLoader... cls) throws ClassNotFoundException {
+        for (ClassLoader cl : cls) {
+            try {
+                return Class.forName(className, false, cl);
+            } catch (ClassNotFoundException _ignored) {
+                // continue
+            }
+        }
+
+        return Class.forName(className, false, FALLBACK_CLASS_LOADER);
+    }
+}

--- a/src/test/java/com/rabbitmq/integration/tests/AbstractITQueue.java
+++ b/src/test/java/com/rabbitmq/integration/tests/AbstractITQueue.java
@@ -14,7 +14,7 @@ import org.junit.After;
 import org.junit.Before;
 
 public abstract class AbstractITQueue {
-    protected QueueConnectionFactory connFactory;
+    QueueConnectionFactory connFactory;
     protected QueueConnection queueConn;
 
     @Before
@@ -24,7 +24,7 @@ public abstract class AbstractITQueue {
         this.queueConn = connFactory.createQueueConnection();
     }
 
-    protected static final void drainQueue(QueueSession session, Queue queue) throws Exception {
+    protected static void drainQueue(QueueSession session, Queue queue) throws Exception {
         QueueReceiver receiver = session.createReceiver(queue);
         int n=0;
         Message msg = receiver.receiveNoWait();
@@ -32,7 +32,9 @@ public abstract class AbstractITQueue {
             ++n;
             msg = receiver.receiveNoWait();
         }
-        if (n>0) System.out.println(">> INFO >> Drained messages (n="+n+") from queue "+queue+" prior to test.");
+        if (n > 0) {
+            System.out.println(">> INFO >> Drained messages (n=" + n + ") from queue " + queue + " prior to test.");
+        }
     }
 
     protected void reconnect() throws Exception {

--- a/src/test/java/com/rabbitmq/integration/tests/AbstractITTopicSSL.java
+++ b/src/test/java/com/rabbitmq/integration/tests/AbstractITTopicSSL.java
@@ -13,6 +13,7 @@ public abstract class AbstractITTopicSSL {
 
     @Before
     public void beforeTests() throws Exception {
+        org.junit.Assume.assumeTrue(Boolean.getBoolean("com.rabbitmq.jms.TLSTests"));
         this.connFactory =
                 (TopicConnectionFactory) AbstractTestConnectionFactory.getTestConnectionFactory(true, 0)
                                                                       .getConnectionFactory();

--- a/src/test/java/com/rabbitmq/integration/tests/ObjectMessageSerializationIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/ObjectMessageSerializationIT.java
@@ -1,0 +1,83 @@
+/* Copyright (c) 2013, 2014 Pivotal Software, Inc. All rights reserved. */
+package com.rabbitmq.integration.tests;
+
+import com.rabbitmq.jms.client.RMQConnection;
+import com.rabbitmq.jms.client.message.RMQObjectMessage;
+import com.rabbitmq.jms.client.message.TestMessages;
+import com.rabbitmq.jms.util.RMQJMSException;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.jms.Queue;
+import javax.jms.QueueReceiver;
+import javax.jms.QueueSender;
+import javax.jms.QueueSession;
+import javax.jms.Session;
+import java.awt.*;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class ObjectMessageSerializationIT extends AbstractITQueue {
+
+    private static final String QUEUE_NAME = "test.queue." + SimpleQueueMessageDefaultsIT.class.getCanonicalName();
+    private static final long TEST_RECEIVE_TIMEOUT = 1000; // one second
+    private static final java.util.List<String> TRUSTED_PACKAGES = Arrays.asList("java.lang", "com.rabbitmq.jms");
+
+    @Before
+    public void configureTrustedPackages() {
+        ((RMQConnection) queueConn).setTrustedPackages(
+                TRUSTED_PACKAGES);
+    }
+
+    protected void testReceiveObjectMessageWithPayload(Object payload) throws Exception {
+        try {
+            queueConn.start();
+            QueueSession queueSession = queueConn.createQueueSession(false, Session.DUPS_OK_ACKNOWLEDGE);
+            Queue queue = queueSession.createQueue(QUEUE_NAME);
+
+            drainQueue(queueSession, queue);
+
+            QueueSender queueSender = queueSession.createSender(queue);
+            queueSender.send(MessageTestType.OBJECT.gen(queueSession, (Serializable) payload));
+        } finally {
+            reconnect();
+            ((RMQConnection) queueConn).setTrustedPackages(
+                    Arrays.asList("java.lang", "com.rabbitmq.jms"));
+        }
+
+        queueConn.start();
+        QueueSession queueSession = queueConn.createQueueSession(false, Session.DUPS_OK_ACKNOWLEDGE);
+        Queue queue = queueSession.createQueue(QUEUE_NAME);
+        QueueReceiver queueReceiver = queueSession.createReceiver(queue);
+        RMQObjectMessage m = (RMQObjectMessage) queueReceiver.receive(TEST_RECEIVE_TIMEOUT);
+        assertEquals(m.getObject(), payload);
+        assertEquals(m.getObject(TRUSTED_PACKAGES), payload);
+    }
+
+    @Test
+    public void testReceiveObjectMessageWithPrimitivePayload() throws Exception {
+        testReceiveObjectMessageWithPayload(1024L);
+        testReceiveObjectMessageWithPayload("a string");
+    }
+
+    @Test
+    public void testReceiveObjectMessageWithTrustedPayload() throws Exception {
+        testReceiveObjectMessageWithPayload(new TestMessages.TestSerializable(8, "An object"));
+    }
+
+    @Test(expected = RMQJMSException.class)
+    public void testReceiveObjectMessageWithUntrustedPayload() throws Exception {
+        // It makes little sense to use ObjectMessage for maps
+        // but someone somewhere certainly does it.
+        // Note: java.util is not on the trusted package list
+        Map<String, String> m = new HashMap<String, String>();
+        m.put("key", "value");
+        testReceiveObjectMessageWithPayload(m);
+        testReceiveObjectMessageWithPayload(Color.WHITE);
+    }
+}
+

--- a/src/test/java/com/rabbitmq/integration/tests/ObjectMessageSerializationIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/ObjectMessageSerializationIT.java
@@ -70,13 +70,17 @@ public class ObjectMessageSerializationIT extends AbstractITQueue {
     }
 
     @Test(expected = RMQJMSException.class)
-    public void testReceiveObjectMessageWithUntrustedPayload() throws Exception {
+    public void testReceiveObjectMessageWithUntrustedPayload1() throws Exception {
         // It makes little sense to use ObjectMessage for maps
         // but someone somewhere certainly does it.
         // Note: java.util is not on the trusted package list
         Map<String, String> m = new HashMap<String, String>();
         m.put("key", "value");
         testReceiveObjectMessageWithPayload(m);
+    }
+    @Test(expected = RMQJMSException.class)
+    public void testReceiveObjectMessageWithUntrustedPayload2() throws Exception {
+        // java.awt is not on the trusted package list
         testReceiveObjectMessageWithPayload(Color.WHITE);
     }
 }

--- a/src/test/java/com/rabbitmq/integration/tests/SSLSimpleQueueMessageIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/SSLSimpleQueueMessageIT.java
@@ -10,6 +10,7 @@ import javax.jms.QueueSender;
 import javax.jms.QueueSession;
 import javax.jms.Session;
 
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -19,6 +20,11 @@ public class SSLSimpleQueueMessageIT extends AbstractITQueueSSL {
 
     private static final String QUEUE_NAME = "test.queue."+SSLSimpleQueueMessageIT.class.getCanonicalName();
     private static final long TEST_RECEIVE_TIMEOUT = 1000; // one second
+
+    @Before
+    public void beforeTests() throws Exception {
+        org.junit.Assume.assumeTrue(Boolean.getBoolean("com.rabbitmq.jms.TLSTests"));
+    }
 
     private void messageTestBase(MessageTestType mtt) throws Exception {
         try {

--- a/src/test/java/com/rabbitmq/integration/tests/SSLSimpleTopicMessageIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/SSLSimpleTopicMessageIT.java
@@ -11,6 +11,7 @@ import javax.jms.TopicPublisher;
 import javax.jms.TopicSession;
 import javax.jms.TopicSubscriber;
 
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -18,6 +19,11 @@ import org.junit.Test;
  */
 public class SSLSimpleTopicMessageIT extends AbstractITTopicSSL {
     private static final String TOPIC_NAME = "test.topic." + SSLSimpleTopicMessageIT.class.getCanonicalName();
+
+    @Before
+    public void beforeTests() throws Exception {
+        org.junit.Assume.assumeTrue(Boolean.getBoolean("com.rabbitmq.jms.TLSTests"));
+    }
 
     @Test
     public void testSendAndReceiveTextMessage() throws Exception {

--- a/src/test/java/com/rabbitmq/jms/admin/RMQConnectionFactoryTest.java
+++ b/src/test/java/com/rabbitmq/jms/admin/RMQConnectionFactoryTest.java
@@ -21,7 +21,7 @@ public class RMQConnectionFactoryTest {
         defaultProps.setProperty("queueBrowserReadMax", "0");
     }
 
-    private static final Properties getProps(Reference ref) {
+    private static Properties getProps(Reference ref) {
         Enumeration<RefAddr> refEnum = ref.getAll();
         Properties props = new Properties();
         while (refEnum.hasMoreElements()) {
@@ -37,9 +37,9 @@ public class RMQConnectionFactoryTest {
      * @param propertyName - the name of the property
      * @param value - the value to store with the property
      */
-    private static final void addStringRefProperty(Reference ref,
-                                                   String propertyName,
-                                                   String value) {
+    private static void addStringRefProperty(Reference ref,
+                                             String propertyName,
+                                             String value) {
         if (value==null || propertyName==null) return;
         removeRefProperty(ref, propertyName);
         RefAddr ra = new StringRefAddr(propertyName, value);
@@ -51,8 +51,8 @@ public class RMQConnectionFactoryTest {
      * @param ref - the reference
      * @param propertyName - the name of the property to remove
      */
-    private static final void removeRefProperty(Reference ref,
-                                                String propertyName) {
+    private static void removeRefProperty(Reference ref,
+                                          String propertyName) {
         if (propertyName==null) return;
         int numProps = ref.size();
         for (int i=0; i < numProps; ++i) {

--- a/src/test/java/com/rabbitmq/jms/client/ForeignBytesMessageTest.java
+++ b/src/test/java/com/rabbitmq/jms/client/ForeignBytesMessageTest.java
@@ -22,40 +22,40 @@ public class ForeignBytesMessageTest {
     public void testBytesMessage() throws Exception {
         BytesMessage testMsg = new ForeignBytesMessage();
         populateBytesMessage(testMsg);
-        BytesMessage rmqMsg = (BytesMessage) RMQMessage.normalise(testMsg);
+        BytesMessage rmqMsg = (BytesMessage) RMQMessage.normalise(testMsg, Collections.singletonList("*"));
         rmqMsg.reset();
         inspectBytesMessage(rmqMsg);
     }
 
     private static final byte[] BYTE_ARRAY = new byte[]{ 0,1,2, (byte) -1 };
     private static final float DELTA = 1.0e-10f;
-    public void populateBytesMessage(BytesMessage message) throws Exception {
+    private void populateBytesMessage(BytesMessage message) throws Exception {
         message.writeBoolean(Boolean.TRUE);
-        message.writeByte(new Byte(Byte.MIN_VALUE));
-        message.writeByte(new Byte((byte) 0xFF));
+        message.writeByte(Byte.MIN_VALUE);
+        message.writeByte((byte) 0xFF);
         message.writeBytes(BYTE_ARRAY);
 
-        message.writeShort(new Short(Short.MIN_VALUE));
-        message.writeShort(new Short((short) 0xFFFF));
-        message.writeChar(new Character(Character.MIN_VALUE));
-        message.writeInt(new Integer(Integer.MIN_VALUE));
-        message.writeLong(new Long(Long.MIN_VALUE));
-        message.writeFloat(new Float(Float.MIN_VALUE));
-        message.writeDouble(new Double(Double.MIN_VALUE));
+        message.writeShort(Short.MIN_VALUE);
+        message.writeShort((short) 0xFFFF);
+        message.writeChar(Character.MIN_VALUE);
+        message.writeInt(Integer.MIN_VALUE);
+        message.writeLong(Long.MIN_VALUE);
+        message.writeFloat(Float.MIN_VALUE);
+        message.writeDouble(Double.MIN_VALUE);
         message.writeUTF("ABC");
 
         message.writeObject(Boolean.TRUE);
-        message.writeObject(new Byte(Byte.MAX_VALUE));
-        message.writeObject(new Short(Short.MAX_VALUE));
-        message.writeObject(new Character(Character.MAX_VALUE));
-        message.writeObject(new Integer(Integer.MAX_VALUE));
-        message.writeObject(new Long(Long.MAX_VALUE));
-        message.writeObject(new Float(Float.MAX_VALUE));
-        message.writeObject(new Double(Double.MAX_VALUE));
+        message.writeObject(Byte.MAX_VALUE);
+        message.writeObject(Short.MAX_VALUE);
+        message.writeObject(Character.MAX_VALUE);
+        message.writeObject(Integer.MAX_VALUE);
+        message.writeObject(Long.MAX_VALUE);
+        message.writeObject(Float.MAX_VALUE);
+        message.writeObject(Double.MAX_VALUE);
         message.writeObject("ABC");
     }
 
-    public void inspectBytesMessage(BytesMessage message) throws Exception {
+    private void inspectBytesMessage(BytesMessage message) throws Exception {
         assertEquals(message.readBoolean(), Boolean.TRUE);
         assertEquals(message.readByte(), Byte.MIN_VALUE);
         assertEquals(message.readByte(), (byte) 0xFF);
@@ -141,10 +141,10 @@ public class ForeignBytesMessageTest {
         @Override public long                   getBodyLength() throws JMSException { return len; }
         @Override public void                   reset() throws JMSException { pos = 0; }
 
-        private static final int ub(byte b) { return (int)b | 0xff; }
-        private final byte nb() { assertTrue(pos<len); return body[pos++]; }
-        private final int pb() { return ub(nb()); }
-        private final long lb() { return pb(); }
+        private static int ub(byte b) { return (int)b | 0xff; }
+        private byte nb() { assertTrue(pos<len); return body[pos++]; }
+        private int pb() { return ub(nb()); }
+        private long lb() { return pb(); }
 
         @Override public boolean                readBoolean() throws JMSException { return nb()!=0; }
         @Override public byte                   readByte() throws JMSException { return nb(); }
@@ -198,13 +198,13 @@ public class ForeignBytesMessageTest {
             else throw new MessageFormatException("Invalid type on writeObject() for TestForeignBytesMessage");
         }
 
-        private static final void writeUTF(ForeignBytesMessage fbmsg, String value) throws JMSException {
+        private static void writeUTF(ForeignBytesMessage fbmsg, String value) throws JMSException {
             byte[] btArr = value.getBytes(UTF8_CHARSET);
             fbmsg.writeShort((short)btArr.length);
             fbmsg.writeBytes(btArr);
         }
 
-        private static final String readUTF(ForeignBytesMessage fbmsg) throws JMSException {
+        private static String readUTF(ForeignBytesMessage fbmsg) throws JMSException {
             int utflen = fbmsg.readUnsignedShort();
 
             byte[] byteArr = new byte[utflen];

--- a/src/test/java/com/rabbitmq/jms/util/TestWhiteListObjectSerialization.java
+++ b/src/test/java/com/rabbitmq/jms/util/TestWhiteListObjectSerialization.java
@@ -1,0 +1,98 @@
+/* Copyright (c) 2013-2016 Pivotal Software, Inc. All rights reserved. */
+package com.rabbitmq.jms.util;
+
+import com.rabbitmq.jms.client.message.RMQObjectMessage;
+import org.junit.Test;
+
+import javax.jms.JMSException;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static junit.framework.TestCase.fail;
+
+public class TestWhiteListObjectSerialization {
+    @Test
+    public void testSuccessfulSerializationWithWildcard() throws IOException, JMSException {
+        expectSuccessWith(Collections.singletonList("*"));
+        // effectively acts as a wildcard. "Trust no package"
+        // doesn't seem to be terribly useful to support.
+        expectSuccessWith(Collections.singletonList(""));
+    }
+
+    @Test
+    public void testSuccessfulSerializationWithWhitelistedClass() throws IOException, JMSException {
+        expectSuccessWith(Collections.singletonList("com.rabbitmq.jms.util"));
+    }
+
+    @Test
+    public void testSuccessfulSerializationWithMultipleWhitelistedClasses() throws IOException, JMSException {
+        expectSuccessWith(Arrays.asList("io.doesnt-match", "jp.co.doesnt-match", "com.rabbitmq.jms.util"));
+    }
+
+    @Test
+    public void testSuccessfulSerializationWithNonWhitelistedClass() throws IOException, JMSException {
+        expecteFailureWith(Collections.singletonList("io.l337h4x0r"), new TestKlazz("abc"));
+        expecteFailureWith(Collections.singletonList("com.whatever"), new TestKlazz("abc"));
+        expecteFailureWith(Collections.singletonList("---"), new TestKlazz("abc"));
+        expecteFailureWith(Collections.singletonList("1234567890"), new TestKlazz("abc"));
+    }
+
+    @Test
+    public void testSuccessWithPrimitiveTypes() throws IOException, JMSException {
+        RMQObjectMessage om = new RMQObjectMessage();
+        om.setObject("JMS");
+
+        RMQObjectMessage.recreate(om, Collections.singletonList("/does/not/match/any/package"));
+    }
+
+    private void expecteFailureWith(List<String> patterns, TestKlazz serializedValue) throws JMSException {
+        RMQObjectMessage om = new RMQObjectMessage();
+        om.setObject(serializedValue);
+        try {
+            RMQObjectMessage.recreate(om, patterns);
+            fail("Expected an exception");
+        } catch (JMSException ignored) {
+        }
+    }
+
+
+    private void expectSuccessWith(List<String> prefixes) throws JMSException {
+        TestKlazz k = new TestKlazz("abc");
+        RMQObjectMessage om = new RMQObjectMessage();
+        om.setObject(k);
+
+        RMQObjectMessage.recreate(om, prefixes);
+    }
+
+
+    @SuppressWarnings("serial")
+    private static class TestKlazz implements Serializable {
+        private final String text;
+
+        TestKlazz(String text) {
+            if (text == null) {
+                throw new IllegalArgumentException("text must not be null");
+            }
+            this.text = text;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            TestKlazz testKlazz = (TestKlazz) o;
+
+            return text.equals(testKlazz.text);
+
+        }
+
+        @Override
+        public int hashCode() {
+            return text.hashCode();
+        }
+    }
+}


### PR DESCRIPTION
Limit ObjectMessage deserialization with a package white list

ObjectMessages in JMS can be used to transfer arbitrary Java objects
which are then deserialized before or at the time of
being passed on to message listeners.

This opens message consumers up to a range of attacks
that exploit issues in Java object serialization.
Note: attacker must authenticate with RabbitMQ in order
to carry out the attack.

With this commit we introduce a way to white list packages
that can be deserialized when ObjectMessages are consumed:

 * Using a system property, `com.rabbitmq.jms.TrustedPackagesPrefixes` (as a comma separated list, e.g. `java,com.rabbitmq,com.myapp`)
 * Using RMQConnectionFactory#setTrustedPackages(List<String>)
 * Using RMQConnection#setTrustedPackages(List<String>)
 * Using RMQSession#setTrustedPackages(List<String>)


By default all packages are trusted for backwards compatibility
(as it's not possible for library maintainers to cover application-specific
packages).

A CVE has been allocated for this issue and will be announced
once a new release is published.

Related issues in other messaging libraries and services:

 * Spring AMQP ticket: https://jira.spring.io/browse/AMQP-590
 * ActiveMQ ticket: https://issues.apache.org/jira/browse/AMQ-6013

Note: this includes a number of small drive-by changes:

 * TLS tests are now executed conditionally and excluded by default
 * Many minor IDEA code analysis fixes
 * JavaDoc warning fixes

Fixes #3.
