### PR TITLE
Provide a way to configure onMessageTimeoutMs

### DIFF
--- a/doc-notes/docupdates1.3.2.md
+++ b/doc-notes/docupdates1.3.2.md
@@ -91,6 +91,13 @@ Here is a complete list of the attributes/properties available:
     <td>RabbitMQ port used for connections. The default is “5672” unless this is an SSL connection, in which case the default is “5671”.</td>
   </tr>
   <tr>
+    <td>onMessageTimeoutMs</td>
+    <td>&nbsp;</td>
+    <td>
+       How long to wait for onMessage to return, in milliseconds. Non-positive values are rejected. The default is “2000”.
+    </td>
+  </tr>
+  <tr>
     <td>queueBrowserReadMax</td>
     <td>&nbsp;</td>
     <td>

--- a/doc-notes/docupdates1.3.2.md
+++ b/doc-notes/docupdates1.3.2.md
@@ -91,13 +91,6 @@ Here is a complete list of the attributes/properties available:
     <td>RabbitMQ port used for connections. The default is “5672” unless this is an SSL connection, in which case the default is “5671”.</td>
   </tr>
   <tr>
-    <td>onMessageTimeoutMs</td>
-    <td>&nbsp;</td>
-    <td>
-       How long to wait for onMessage to return, in milliseconds. Non-positive values are rejected. The default is “2000”.
-    </td>
-  </tr>
-  <tr>
     <td>queueBrowserReadMax</td>
     <td>&nbsp;</td>
     <td>

--- a/src/main/java/com/rabbitmq/jms/admin/RMQObjectFactory.java
+++ b/src/main/java/com/rabbitmq/jms/admin/RMQObjectFactory.java
@@ -77,6 +77,7 @@ import org.slf4j.LoggerFactory;
  * <li>password</li>
  * <li>port</li>
  * <li>queueBrowserReadMax</li>
+ * <li>onMessageTimeoutMs</li>
  * <li>ssl</li>
  * <li>terminationTimeout</li>
  * <li>username</li>
@@ -165,6 +166,7 @@ public class RMQObjectFactory implements ObjectFactory {
         f.setPassword           (getStringProperty (ref, "password",            true, f.getPassword()           ));
         f.setPort               (getIntProperty    (ref, "port",                true, f.getPort()               ));
         f.setQueueBrowserReadMax(getIntProperty    (ref, "queueBrowserReadMax", true, f.getQueueBrowserReadMax()));
+        f.setOnMessageTimeoutMs (getIntProperty    (ref, "onMessageTimeoutMs",  true, f.getOnMessageTimeoutMs() ));
         f.setSsl                (getBooleanProperty(ref, "ssl",                 true, f.isSsl()                 ));
         f.setTerminationTimeout (getLongProperty   (ref, "terminationTimeout",  true, f.getTerminationTimeout() ));
         f.setUsername           (getStringProperty (ref, "username",            true, f.getUsername()           ));

--- a/src/test/java/com/rabbitmq/jms/admin/RMQConnectionFactoryTest.java
+++ b/src/test/java/com/rabbitmq/jms/admin/RMQConnectionFactoryTest.java
@@ -19,6 +19,7 @@ public class RMQConnectionFactoryTest {
         RMQConnectionFactory defaultFact = new RMQConnectionFactory();
         defaultProps.setProperty("uri", defaultFact.getUri());
         defaultProps.setProperty("queueBrowserReadMax", "0");
+        defaultProps.setProperty("onMessageTimeoutMs", "2000");
     }
 
     private static Properties getProps(Reference ref) {
@@ -79,6 +80,7 @@ public class RMQConnectionFactoryTest {
         connFactory.setPassword("my-password");
         connFactory.setPort(42);
         connFactory.setQueueBrowserReadMax(52);
+        connFactory.setOnMessageTimeoutMs(62);
         connFactory.setSsl(true);
         connFactory.setTerminationTimeout(1234567890123456789L);
         connFactory.setUsername("fred");
@@ -89,6 +91,7 @@ public class RMQConnectionFactoryTest {
 
         assertEquals("Not the correct uri", "amqps://fred:my-password@sillyHost:42/bill", newProps.getProperty("uri"));
         assertEquals("Not the correct queueBrowserReadMax", "52", newProps.getProperty("queueBrowserReadMax"));
+        assertEquals("Not the correct onMessageTimeoutMs", "62", newProps.getProperty("onMessageTimeoutMs"));
     }
 
     @Test
@@ -133,6 +136,7 @@ public class RMQConnectionFactoryTest {
         addStringRefProperty(ref, "password", "my-password");
         addStringRefProperty(ref, "port", "42");
         addStringRefProperty(ref, "queueBrowserReadMax", "52"); // duplicates don't overwrite
+        addStringRefProperty(ref, "onMessageTimeoutMs", "62");
         addStringRefProperty(ref, "ssl", "true");
         addStringRefProperty(ref, "terminationTimeout","1234567890123456789");
         addStringRefProperty(ref, "username", "fred");
@@ -144,6 +148,7 @@ public class RMQConnectionFactoryTest {
         assertEquals("Not the correct password", "my-password", newFactory.getPassword());
         assertEquals("Not the correct port", 42, newFactory.getPort());
         assertEquals("Not the correct queueBrowserReadMax", 52, newFactory.getQueueBrowserReadMax());
+        assertEquals("Not the correct onMessageTimeoutMs", 62, newFactory.getOnMessageTimeoutMs());
         assertEquals("Not the correct ssl", true, newFactory.isSsl());
 
         assertEquals("Not the correct terminationTimeout", 1234567890123456789L, newFactory.getTerminationTimeout());


### PR DESCRIPTION
Adds onMessageTimeoutMs as a JNDI property,
- ...read by `RMQObjectFactory`, defaults to 2000ms
- ...propagated to `RMQConnectionFactory`
- ...propagated to `RMQConnection`
- ...propagated to `RMQSession`
- updated test `RMQConnectionFactoryTest`
- updated documentation `docupdates1.3.2.md`

Integration tests (`mvn clean verify`) still work.

Implements #5 