### PR TITLE
Let RMQObjectFactory handle properties from a hash table

### DIFF
--- a/doc-notes/docupdates1.1.0.md
+++ b/doc-notes/docupdates1.1.0.md
@@ -77,19 +77,6 @@ or a Spring bean example:
   </bean>
 ```
 
-or a Wildfly xml configuration example with amqp default value:
-
-```xml
-<bindings>
-    <object-factory name="java:global/jms/Queue" module="foo.bar" class="com.rabbitmq.jms.admin.RMQObjectFactory">
-        <environment>
-            <property name="className" value="javax.jms.Queue"/>
-            <property name="destinationName" value="myQueue"/>
-        </environment>
-    </object-factory>
-</bindings>
-```
-
 Here is a *complete* list of the attributes/properties now available:
 
 ----
@@ -184,23 +171,6 @@ or a Spring bean example:
     <property name="host" value="localhost" />
     <property name="ssl" value="true" />
   </bean>
-```
-
-or a Wildfly xml configuration example:
-
-```xml
-<bindings>
-    <object-factory name="java:global/jms/ConnectionFactory" module="org.jboss.genericjms.provider" class="com.rabbitmq.jms.admin.RMQObjectFactory">
-        <environment>
-            <property name="className" value="javax.jms.ConnectionFactory"/>
-            <property name="username" value="guest"/>
-            <property name="password" value="guest"/>
-            <property name="virtualHost" value="/"/>
-            <property name="host" value="localhost"/>
-            <property name="ssl" value="true"/>
-        </environment>
-    </object-factory>
-</bindings>
 ```
 
 Here is a complete list of the attributes/properties available:

--- a/doc-notes/docupdates1.1.0.md
+++ b/doc-notes/docupdates1.1.0.md
@@ -77,6 +77,19 @@ or a Spring bean example:
   </bean>
 ```
 
+or a Wildfly xml configuration example with amqp default value:
+
+```xml
+<bindings>
+    <object-factory name="java:global/jms/Queue" module="foo.bar" class="com.rabbitmq.jms.admin.RMQObjectFactory">
+        <environment>
+            <property name="className" value="javax.jms.Queue"/>
+            <property name="destinationName" value="myQueue"/>
+        </environment>
+    </object-factory>
+</bindings>
+```
+
 Here is a *complete* list of the attributes/properties now available:
 
 ----
@@ -171,6 +184,23 @@ or a Spring bean example:
     <property name="host" value="localhost" />
     <property name="ssl" value="true" />
   </bean>
+```
+
+or a Wildfly xml configuration example:
+
+```xml
+<bindings>
+    <object-factory name="java:global/jms/ConnectionFactory" module="org.jboss.genericjms.provider" class="com.rabbitmq.jms.admin.RMQObjectFactory">
+        <environment>
+            <property name="className" value="javax.jms.ConnectionFactory"/>
+            <property name="username" value="guest"/>
+            <property name="password" value="guest"/>
+            <property name="virtualHost" value="/"/>
+            <property name="host" value="localhost"/>
+            <property name="ssl" value="true"/>
+        </environment>
+    </object-factory>
+</bindings>
 ```
 
 Here is a complete list of the attributes/properties available:

--- a/doc-notes/docupdates1.3.2.md
+++ b/doc-notes/docupdates1.3.2.md
@@ -1,4 +1,4 @@
-# Java JMS Client Documentation Changes for RJMS 1.3.3
+# Java JMS Client Documentation Changes for RJMS 1.7.0
 
 ----
 
@@ -31,23 +31,6 @@ or a Spring bean example:
     <property name="host" value="localhost" />
     <property name="ssl" value="true" />
   </bean>
-```
-
-or a Wildfly xml configuration example:
-
-```xml
-<bindings>
-    <object-factory name="java:global/jms/ConnectionFactory" module="org.jboss.genericjms.provider" class="com.rabbitmq.jms.admin.RMQObjectFactory">
-        <environment>
-            <property name="className" value="javax.jms.ConnectionFactory"/>
-            <property name="username" value="guest"/>
-            <property name="password" value="guest"/>
-            <property name="virtualHost" value="/"/>
-            <property name="host" value="localhost"/>
-            <property name="ssl" value="true"/>
-        </environment>
-    </object-factory>
-</bindings>
 ```
 
 Here is a complete list of the attributes/properties available:

--- a/doc-notes/docupdates1.3.2.md
+++ b/doc-notes/docupdates1.3.2.md
@@ -33,6 +33,23 @@ or a Spring bean example:
   </bean>
 ```
 
+or a Wildfly xml configuration example:
+
+```xml
+<bindings>
+    <object-factory name="java:global/jms/ConnectionFactory" module="org.jboss.genericjms.provider" class="com.rabbitmq.jms.admin.RMQObjectFactory">
+        <environment>
+            <property name="className" value="javax.jms.ConnectionFactory"/>
+            <property name="username" value="guest"/>
+            <property name="password" value="guest"/>
+            <property name="virtualHost" value="/"/>
+            <property name="host" value="localhost"/>
+            <property name="ssl" value="true"/>
+        </environment>
+    </object-factory>
+</bindings>
+```
+
 Here is a complete list of the attributes/properties available:
 
 ----

--- a/src/test/java/com/rabbitmq/jms/admin/RMQObjectFactoryTest.java
+++ b/src/test/java/com/rabbitmq/jms/admin/RMQObjectFactoryTest.java
@@ -1,0 +1,165 @@
+package com.rabbitmq.jms.admin;
+
+import org.junit.Test;
+
+import javax.jms.ConnectionFactory;
+import javax.naming.CompositeName;
+import javax.naming.NamingException;
+import javax.naming.Reference;
+import java.util.Hashtable;
+
+import static org.junit.Assert.*;
+
+/**
+ * RMQObjectFactory unit test
+ *
+ * @author Rémi Bantos
+ */
+public class RMQObjectFactoryTest {
+
+    private RMQObjectFactory rmqObjectFactory = new RMQObjectFactory();
+
+    @Test
+    public void getObjectInstance_should_create_a_RMQConnectionFactory_via_Reference() throws Exception {
+
+        Reference ref = new Reference(ConnectionFactory.class.getName());
+
+        Object createdObject = rmqObjectFactory.getObjectInstance(ref, new CompositeName("java:global/jms/TestConnectionFactory"), null, null);
+
+        assertNotNull(createdObject);
+        assertEquals(RMQConnectionFactory.class, createdObject.getClass());
+
+        RMQConnectionFactory createdConFactory = (RMQConnectionFactory) createdObject;
+
+        assertEquals("guest", createdConFactory.getUsername());
+        assertEquals("guest", createdConFactory.getPassword());
+        assertEquals("/", createdConFactory.getVirtualHost());
+        assertEquals("localhost", createdConFactory.getHost());
+
+    }
+
+
+    @Test
+    public void getObjectInstance_should_create_a_RMQConnectionFactory_via_environment() throws Exception {
+
+        Hashtable<?, ?> environment = new Hashtable<Object, Object>() {{
+            put("className", "javax.jms.ConnectionFactory");
+            put("username", "remi");
+            put("password", "1234");
+            put("virtualHost", "/fake");
+            put("host", "fakeHost");
+        }};
+
+        Object createdObject = rmqObjectFactory.getObjectInstance("anything but a javax.naming.Reference", new CompositeName("java:global/jms/TestConnectionFactory"), null, environment);
+
+        assertNotNull(createdObject);
+        assertEquals(RMQConnectionFactory.class, createdObject.getClass());
+
+        RMQConnectionFactory createdConFactory = (RMQConnectionFactory) createdObject;
+
+        assertEquals("remi", createdConFactory.getUsername());
+        assertEquals("1234", createdConFactory.getPassword());
+        assertEquals("/fake", createdConFactory.getVirtualHost());
+        assertEquals("fakeHost", createdConFactory.getHost());
+
+    }
+
+    @Test
+    public void getObjectInstance_should_create_a_RMQDestination_QUEUE_via_environment() throws Exception {
+
+        Hashtable<?, ?> environment = new Hashtable<Object, Object>() {{
+            put("className", "javax.jms.Queue");
+            put("destinationName", "TEST_QUEUE");
+        }};
+
+        Object createdObject = rmqObjectFactory.getObjectInstance("anything but a javax.naming.Reference", new CompositeName("java:global/jms/TestQueue"), null, environment);
+
+        assertNotNull(createdObject);
+        assertEquals(RMQDestination.class, createdObject.getClass());
+
+        RMQDestination createdDestination = (RMQDestination) createdObject;
+
+        assertEquals("TEST_QUEUE", createdDestination.getDestinationName());
+        assertEquals("TEST_QUEUE", createdDestination.getQueueName());
+
+    }
+
+
+    @Test
+    public void getObjectInstance_should_create_a_RMQDestination_TOPIC_via_environment() throws Exception {
+
+        Hashtable<?, ?> environment = new Hashtable<Object, Object>() {{
+            put("className", "javax.jms.Topic");
+            put("destinationName", "TEST_TOPIC");
+        }};
+
+        Object createdObject = rmqObjectFactory.getObjectInstance("anything but a javax.naming.Reference", new CompositeName("java:global/jms/TestTopic"), null, environment);
+
+        assertNotNull(createdObject);
+        assertEquals(RMQDestination.class, createdObject.getClass());
+
+        RMQDestination createdDestination = (RMQDestination) createdObject;
+
+        assertEquals("TEST_TOPIC", createdDestination.getDestinationName());
+        assertEquals("TEST_TOPIC", createdDestination.getTopicName());
+
+    }
+
+
+    @Test
+    public void getObjectInstance_should_throw_NamingException_when_missing_required_property_via_environment() throws Exception {
+
+        Hashtable<?, ?> environment = new Hashtable<Object, Object>() {{
+            put("className", "javax.jms.Queue");
+            put("destinationName", "TEST_QUEUE");
+            put("amqp", "true");
+        }};
+
+        try {
+            rmqObjectFactory.getObjectInstance("anything but a javax.naming.Reference", new CompositeName("java:global/jms/TestConnectionFactory"), null, environment);
+        } catch (NamingException ne) {
+            assertEquals("Property [amqpExchangeName] may not be null.", ne.getMessage());
+        }
+
+    }
+
+    @Test
+    public void getObjectInstance_should_return_null_object_arg_is_null() throws Exception {
+
+        assertNull(rmqObjectFactory.getObjectInstance(null, new CompositeName("java:global/jms/TestConnectionFactory"), null, null));
+    }
+
+    @Test
+    public void getObjectInstance_should_throw_NamingException_when_object_arg_is_not_a_Reference_and_environment_is_null() throws Exception {
+
+        try {
+            rmqObjectFactory.getObjectInstance("anything but a javax.naming.Reference", new CompositeName("java:global/jms/TestConnectionFactory"), null, null);
+        } catch (NamingException ne) {
+            assertEquals("Unable to instantiate object: obj is not a Reference instance and environment table is empty", ne.getMessage());
+        }
+    }
+
+    @Test
+    public void getObjectInstance_should_throw_NamingException_when_object_arg_is_not_a_Reference_and_environment_is_empty() throws Exception {
+
+        try {
+            rmqObjectFactory.getObjectInstance("anything but a javax.naming.Reference", new CompositeName("java:global/jms/TestConnectionFactory"), null, new Hashtable<Object, Object>());
+        } catch (NamingException ne) {
+            assertEquals("Unable to instantiate object: obj is not a Reference instance and environment table is empty", ne.getMessage());
+        }
+    }
+
+    @Test
+    public void getObjectInstance_should_throw_NamingException_when_object_arg_is_not_a_Reference_and_environment_className_is_missing() throws Exception {
+
+        try {
+            Hashtable<Object, Object> environment = new Hashtable<Object, Object>() {{
+                put("anything but className", "some value");
+            }};
+            rmqObjectFactory.getObjectInstance("anything but a javax.naming.Reference", new CompositeName("java:global/jms/TestConnectionFactory"), null, environment);
+        } catch (NamingException ne) {
+            assertEquals("Unable to instantiate object: type has not been specified", ne.getMessage());
+        }
+    }
+
+}

--- a/src/test/java/com/rabbitmq/jms/admin/RMQObjectFactoryTest.java
+++ b/src/test/java/com/rabbitmq/jms/admin/RMQObjectFactoryTest.java
@@ -117,6 +117,7 @@ public class RMQObjectFactoryTest {
 
         try {
             rmqObjectFactory.getObjectInstance("anything but a javax.naming.Reference", new CompositeName("java:global/jms/TestConnectionFactory"), null, environment);
+            fail("Should have thrown a NamingException");
         } catch (NamingException ne) {
             assertEquals("Property [amqpExchangeName] may not be null.", ne.getMessage());
         }
@@ -134,6 +135,7 @@ public class RMQObjectFactoryTest {
 
         try {
             rmqObjectFactory.getObjectInstance("anything but a javax.naming.Reference", new CompositeName("java:global/jms/TestConnectionFactory"), null, null);
+            fail("Should have thrown a NamingException");
         } catch (NamingException ne) {
             assertEquals("Unable to instantiate object: obj is not a Reference instance and environment table is empty", ne.getMessage());
         }
@@ -144,6 +146,7 @@ public class RMQObjectFactoryTest {
 
         try {
             rmqObjectFactory.getObjectInstance("anything but a javax.naming.Reference", new CompositeName("java:global/jms/TestConnectionFactory"), null, new Hashtable<Object, Object>());
+            fail("Should have thrown a NamingException");
         } catch (NamingException ne) {
             assertEquals("Unable to instantiate object: obj is not a Reference instance and environment table is empty", ne.getMessage());
         }
@@ -157,6 +160,7 @@ public class RMQObjectFactoryTest {
                 put("anything but className", "some value");
             }};
             rmqObjectFactory.getObjectInstance("anything but a javax.naming.Reference", new CompositeName("java:global/jms/TestConnectionFactory"), null, environment);
+            fail("Should have thrown a NamingException");
         } catch (NamingException ne) {
             assertEquals("Unable to instantiate object: type has not been specified", ne.getMessage());
         }

--- a/src/test/java/com/rabbitmq/jms/admin/RMQObjectFactoryTest.java
+++ b/src/test/java/com/rabbitmq/jms/admin/RMQObjectFactoryTest.java
@@ -20,7 +20,7 @@ public class RMQObjectFactoryTest {
     private RMQObjectFactory rmqObjectFactory = new RMQObjectFactory();
 
     @Test
-    public void getObjectInstance_should_create_a_RMQConnectionFactory_via_Reference() throws Exception {
+    public void getObjectInstanceShouldCreateARMQConnectionFactoryViaReference() throws Exception {
 
         Reference ref = new Reference(ConnectionFactory.class.getName());
 
@@ -40,7 +40,7 @@ public class RMQObjectFactoryTest {
 
 
     @Test
-    public void getObjectInstance_should_create_a_RMQConnectionFactory_via_environment() throws Exception {
+    public void getObjectInstanceShouldCreateARMQConnectionFactoryViaEnvironment() throws Exception {
 
         Hashtable<?, ?> environment = new Hashtable<Object, Object>() {{
             put("className", "javax.jms.ConnectionFactory");
@@ -65,7 +65,7 @@ public class RMQObjectFactoryTest {
     }
 
     @Test
-    public void getObjectInstance_should_create_a_RMQDestination_QUEUE_via_environment() throws Exception {
+    public void getObjectInstanceShouldCreateARMQDestinationQUEUEViaEnvironment() throws Exception {
 
         Hashtable<?, ?> environment = new Hashtable<Object, Object>() {{
             put("className", "javax.jms.Queue");
@@ -86,7 +86,7 @@ public class RMQObjectFactoryTest {
 
 
     @Test
-    public void getObjectInstance_should_create_a_RMQDestination_TOPIC_via_environment() throws Exception {
+    public void getObjectInstanceShouldCreateARMQDestinationTOPICViaEnvironment() throws Exception {
 
         Hashtable<?, ?> environment = new Hashtable<Object, Object>() {{
             put("className", "javax.jms.Topic");
@@ -107,7 +107,7 @@ public class RMQObjectFactoryTest {
 
 
     @Test
-    public void getObjectInstance_should_throw_NamingException_when_missing_required_property_via_environment() throws Exception {
+    public void getObjectInstanceShouldThrowNamingExceptionWhenMissingRequiredPropertyViaEnvironment() throws Exception {
 
         Hashtable<?, ?> environment = new Hashtable<Object, Object>() {{
             put("className", "javax.jms.Queue");
@@ -124,13 +124,13 @@ public class RMQObjectFactoryTest {
     }
 
     @Test
-    public void getObjectInstance_should_return_null_object_arg_is_null() throws Exception {
+    public void getObjectInstanceShouldReturnNullObjectWhenObjectArgIsNull() throws Exception {
 
         assertNull(rmqObjectFactory.getObjectInstance(null, new CompositeName("java:global/jms/TestConnectionFactory"), null, null));
     }
 
     @Test
-    public void getObjectInstance_should_throw_NamingException_when_object_arg_is_not_a_Reference_and_environment_is_null() throws Exception {
+    public void getObjectInstanceShouldThrowNamingExceptionWhenObjectArgIsNotAReferenceAndEnvironmentIsNull() throws Exception {
 
         try {
             rmqObjectFactory.getObjectInstance("anything but a javax.naming.Reference", new CompositeName("java:global/jms/TestConnectionFactory"), null, null);
@@ -140,7 +140,7 @@ public class RMQObjectFactoryTest {
     }
 
     @Test
-    public void getObjectInstance_should_throw_NamingException_when_object_arg_is_not_a_Reference_and_environment_is_empty() throws Exception {
+    public void getObjectInstanceShouldThrowNamingExceptionWhenObjectArgIsNotAReferenceAndEnvironmentIsempty() throws Exception {
 
         try {
             rmqObjectFactory.getObjectInstance("anything but a javax.naming.Reference", new CompositeName("java:global/jms/TestConnectionFactory"), null, new Hashtable<Object, Object>());
@@ -150,7 +150,7 @@ public class RMQObjectFactoryTest {
     }
 
     @Test
-    public void getObjectInstance_should_throw_NamingException_when_object_arg_is_not_a_Reference_and_environment_className_is_missing() throws Exception {
+    public void getObjectInstanceShouldThrowNamingExceptionWhenObjectArgIsNotAReferenceAndEnvironmentClassNameIsMissing() throws Exception {
 
         try {
             Hashtable<Object, Object> environment = new Hashtable<Object, Object>() {{


### PR DESCRIPTION
# PR Description
Fixes #21 issue.
Allows the user to create client objects on Wildfly via Naming subsystem configuration.

# Wildfly Naming subsystem configuration

## Introduction
See Wildfly  [JNDI Reference - Naming Subsystem Configuration](https://docs.jboss.org/author/display/WFLY10/JNDI+Reference#JNDIReference-NamingSubsystemConfiguration).

All the properties documented for Tomcat and Spring in [RabbitMQ JMS client](https://www.rabbitmq.com/jms-client.html) documentation are available. 
They have to be configured within environment element of Wildfly object-factory binding configuration.

Note that a new property called _className_ has to be provided, it describes the type of object to create, among the following possible values:
* javax.jms.ConnectionFactory
* javax.jms.QueueConnectionFactory
* javax.jms.TopicConnectionFactory
* javax.jms.Topic
* javax.jms.Queue

## Defining the JMS Connection Factory

```xml
<bindings>
    <object-factory name="java:global/jms/ConnectionFactory" module="foo.bar" class="com.rabbitmq.jms.admin.RMQObjectFactory">
        <environment>
            <property name="className" value="javax.jms.ConnectionFactory"/>
            <property name="username" value="guest"/>
            <property name="password" value="guest"/>
            <property name="virtualHost" value="/"/>
            <property name="host" value="localhost"/>
            <property name="ssl" value="true"/>
        </environment>
    </object-factory>
</bindings>
```
## JMS AMQP 0-9-1 Destination Definitions

```xml
<bindings>
    <object-factory name="java:global/jms/Queue" module="foo.bar" class="com.rabbitmq.jms.admin.RMQObjectFactory">
        <environment>
            <property name="className" value="javax.jms.Queue"/>
            <property name="destinationName" value="myQueue"/>
        </environment>
    </object-factory>
</bindings>
```