### PR TITLE
Take message properties into account on sending

### DIFF
--- a/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
@@ -115,7 +115,7 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
             .setQueueBrowserReadMax(getQueueBrowserReadMax())
             .setOnMessageTimeoutMs(getOnMessageTimeoutMs())
             .setChannelsQos(channelsQos)
-            .setMessageProducerPropertyPrioritary(preferMessagePropertiesFromProducer)
+            .setPreferProducerMessageProperty(preferMessagePropertiesFromProducer)
         );
         conn.setTrustedPackages(this.trustedPackages);
         logger.debug("Connection {} created.", conn);
@@ -137,7 +137,7 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
             .setQueueBrowserReadMax(getQueueBrowserReadMax())
             .setOnMessageTimeoutMs(getOnMessageTimeoutMs())
             .setChannelsQos(channelsQos)
-            .setMessageProducerPropertyPrioritary(preferMessagePropertiesFromProducer)
+            .setPreferProducerMessageProperty(preferMessagePropertiesFromProducer)
         );
         conn.setTrustedPackages(this.trustedPackages);
         logger.debug("Connection {} created.", conn);

--- a/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2013 Pivotal Software, Inc. All rights reserved. */
+/* Copyright (c) 2013-2017 Pivotal Software, Inc. All rights reserved. */
 package com.rabbitmq.jms.admin;
 
 import com.rabbitmq.client.Address;
@@ -48,6 +48,13 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
     private int port = -1;
     /** How long to wait for onMessage to return, in milliseconds */
     private int onMessageTimeoutMs = 2000;
+    /**
+     * Whether {@link MessageProducer} properties (delivery mode,
+     * priority, TTL) take precedence over respective {@link Message}
+     * properties or not.
+     * Default is true (which is compliant to the JMS specification).
+     */
+    private boolean messageProducerPropertyPrioritary = true;
 
     /** Default not to use ssl */
     private boolean ssl = false;
@@ -108,6 +115,7 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
             .setQueueBrowserReadMax(getQueueBrowserReadMax())
             .setOnMessageTimeoutMs(getOnMessageTimeoutMs())
             .setChannelsQos(channelsQos)
+            .setMessageProducerPropertyPrioritary(messageProducerPropertyPrioritary)
         );
         conn.setTrustedPackages(this.trustedPackages);
         logger.debug("Connection {} created.", conn);
@@ -128,6 +136,8 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
             .setTerminationTimeout(getTerminationTimeout())
             .setQueueBrowserReadMax(getQueueBrowserReadMax())
             .setOnMessageTimeoutMs(getOnMessageTimeoutMs())
+            .setChannelsQos(channelsQos)
+            .setMessageProducerPropertyPrioritary(messageProducerPropertyPrioritary)
         );
         conn.setTrustedPackages(this.trustedPackages);
         logger.debug("Connection {} created.", conn);
@@ -627,5 +637,19 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
      */
     public void setChannelsQos(int channelsQos) {
         this.channelsQos = channelsQos;
+    }
+
+    /**
+     * Whether {@link MessageProducer} properties (delivery mode,
+     * priority, TTL) take precedence over respective {@link Message}
+     * properties or not.
+     * Default is true (which is compliant to the JMS specification).
+     */
+    public void setMessageProducerPropertyPrioritary(boolean messageProducerPropertyPrioritary) {
+        this.messageProducerPropertyPrioritary = messageProducerPropertyPrioritary;
+    }
+
+    public boolean isMessageProducerPropertyPrioritary() {
+        return messageProducerPropertyPrioritary;
     }
 }

--- a/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
@@ -54,7 +54,7 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
      * properties or not.
      * Default is true (which is compliant to the JMS specification).
      */
-    private boolean preferMessagePropertiesFromProducer = true;
+    private boolean preferProducerMessageProperty = true;
 
     /** Default not to use ssl */
     private boolean ssl = false;
@@ -115,7 +115,7 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
             .setQueueBrowserReadMax(getQueueBrowserReadMax())
             .setOnMessageTimeoutMs(getOnMessageTimeoutMs())
             .setChannelsQos(channelsQos)
-            .setPreferProducerMessageProperty(preferMessagePropertiesFromProducer)
+            .setPreferProducerMessageProperty(preferProducerMessageProperty)
         );
         conn.setTrustedPackages(this.trustedPackages);
         logger.debug("Connection {} created.", conn);
@@ -137,7 +137,7 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
             .setQueueBrowserReadMax(getQueueBrowserReadMax())
             .setOnMessageTimeoutMs(getOnMessageTimeoutMs())
             .setChannelsQos(channelsQos)
-            .setPreferProducerMessageProperty(preferMessagePropertiesFromProducer)
+            .setPreferProducerMessageProperty(preferProducerMessageProperty)
         );
         conn.setTrustedPackages(this.trustedPackages);
         logger.debug("Connection {} created.", conn);
@@ -645,11 +645,11 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
      * properties or not.
      * Default is true (which is compliant to the JMS specification).
      */
-    public void setPreferMessagePropertiesFromProducer(boolean preferMessagePropertiesFromProducer) {
-        this.preferMessagePropertiesFromProducer = preferMessagePropertiesFromProducer;
+    public void setPreferProducerMessageProperty(boolean preferProducerMessageProperty) {
+        this.preferProducerMessageProperty = preferProducerMessageProperty;
     }
 
-    public boolean isPreferMessagePropertiesFromProducer() {
-        return preferMessagePropertiesFromProducer;
+    public boolean isPreferProducerMessageProperty() {
+        return preferProducerMessageProperty;
     }
 }

--- a/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
@@ -54,7 +54,7 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
      * properties or not.
      * Default is true (which is compliant to the JMS specification).
      */
-    private boolean messageProducerPropertyPrioritary = true;
+    private boolean preferMessagePropertiesFromProducer = true;
 
     /** Default not to use ssl */
     private boolean ssl = false;
@@ -115,7 +115,7 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
             .setQueueBrowserReadMax(getQueueBrowserReadMax())
             .setOnMessageTimeoutMs(getOnMessageTimeoutMs())
             .setChannelsQos(channelsQos)
-            .setMessageProducerPropertyPrioritary(messageProducerPropertyPrioritary)
+            .setMessageProducerPropertyPrioritary(preferMessagePropertiesFromProducer)
         );
         conn.setTrustedPackages(this.trustedPackages);
         logger.debug("Connection {} created.", conn);
@@ -137,7 +137,7 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
             .setQueueBrowserReadMax(getQueueBrowserReadMax())
             .setOnMessageTimeoutMs(getOnMessageTimeoutMs())
             .setChannelsQos(channelsQos)
-            .setMessageProducerPropertyPrioritary(messageProducerPropertyPrioritary)
+            .setMessageProducerPropertyPrioritary(preferMessagePropertiesFromProducer)
         );
         conn.setTrustedPackages(this.trustedPackages);
         logger.debug("Connection {} created.", conn);
@@ -645,11 +645,11 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
      * properties or not.
      * Default is true (which is compliant to the JMS specification).
      */
-    public void setMessageProducerPropertyPrioritary(boolean messageProducerPropertyPrioritary) {
-        this.messageProducerPropertyPrioritary = messageProducerPropertyPrioritary;
+    public void setPreferMessagePropertiesFromProducer(boolean preferMessagePropertiesFromProducer) {
+        this.preferMessagePropertiesFromProducer = preferMessagePropertiesFromProducer;
     }
 
-    public boolean isMessageProducerPropertyPrioritary() {
-        return messageProducerPropertyPrioritary;
+    public boolean isPreferMessagePropertiesFromProducer() {
+        return preferMessagePropertiesFromProducer;
     }
 }

--- a/src/main/java/com/rabbitmq/jms/client/ConnectionParams.java
+++ b/src/main/java/com/rabbitmq/jms/client/ConnectionParams.java
@@ -36,7 +36,7 @@ public class ConnectionParams {
      * properties or not.
      * Default is true.
      */
-    private boolean messageProducerPropertyPrioritary = true;
+    private boolean preferProducerMessageProperty = true;
 
     public Connection getRabbitConnection() {
         return rabbitConnection;
@@ -83,12 +83,12 @@ public class ConnectionParams {
         return this;
     }
 
-    public boolean isMessageProducerPropertyPrioritary() {
-        return messageProducerPropertyPrioritary;
+    public boolean willPreferProducerMessageProperty() {
+        return preferProducerMessageProperty;
     }
 
-    public ConnectionParams setMessageProducerPropertyPrioritary(boolean messageProducerPropertyPrioritary) {
-        this.messageProducerPropertyPrioritary = messageProducerPropertyPrioritary;
+    public ConnectionParams setPreferProducerMessageProperty(boolean preferProducerMessageProperty) {
+        this.preferProducerMessageProperty = preferProducerMessageProperty;
         return this;
     }
 }

--- a/src/main/java/com/rabbitmq/jms/client/ConnectionParams.java
+++ b/src/main/java/com/rabbitmq/jms/client/ConnectionParams.java
@@ -1,7 +1,10 @@
-/* Copyright (c) 2016 Pivotal Software, Inc. All rights reserved. */
+/* Copyright (c) 2016-2017 Pivotal Software, Inc. All rights reserved. */
 package com.rabbitmq.jms.client;
 
 import com.rabbitmq.client.Connection;
+
+import javax.jms.Message;
+import javax.jms.MessageProducer;
 
 /**
  * Holder for {@link RMQConnection} constructor arguments.
@@ -26,6 +29,14 @@ public class ConnectionParams {
      * @see com.rabbitmq.client.Channel#basicQos(int)
      */
     private int channelsQos = RMQConnection.NO_CHANNEL_QOS;
+
+    /**
+     * Whether {@link MessageProducer} properties (delivery mode,
+     * priority, TTL) take precedence over respective {@link Message}
+     * properties or not.
+     * Default is true.
+     */
+    private boolean messageProducerPropertyPrioritary = true;
 
     public Connection getRabbitConnection() {
         return rabbitConnection;
@@ -69,6 +80,15 @@ public class ConnectionParams {
 
     public ConnectionParams setChannelsQos(int channelsQos) {
         this.channelsQos = channelsQos;
+        return this;
+    }
+
+    public boolean isMessageProducerPropertyPrioritary() {
+        return messageProducerPropertyPrioritary;
+    }
+
+    public ConnectionParams setMessageProducerPropertyPrioritary(boolean messageProducerPropertyPrioritary) {
+        this.messageProducerPropertyPrioritary = messageProducerPropertyPrioritary;
         return this;
     }
 }

--- a/src/main/java/com/rabbitmq/jms/client/RMQConnection.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQConnection.java
@@ -82,7 +82,7 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
      * properties or not.
      * Default is true.
      */
-    private boolean messageProducerPropertyPrioritary;
+    private boolean preferProducerMessageProperty;
 
     /**
      * Classes in these packages can be transferred via ObjectMessage.
@@ -104,7 +104,7 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
         this.queueBrowserReadMax = connectionParams.getQueueBrowserReadMax();
         this.onMessageTimeoutMs = connectionParams.getOnMessageTimeoutMs();
         this.channelsQos = connectionParams.getChannelsQos();
-        this.messageProducerPropertyPrioritary = connectionParams.isMessageProducerPropertyPrioritary();
+        this.preferProducerMessageProperty = connectionParams.willPreferProducerMessageProperty();
     }
 
     /**
@@ -150,7 +150,7 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
             .setOnMessageTimeoutMs(onMessageTimeoutMs)
             .setMode(acknowledgeMode)
             .setSubscriptions(this.subscriptions)
-            .setMessageProducerPropertyPrioritary(this.messageProducerPropertyPrioritary)
+            .setPreferProducerMessageProperty(this.preferProducerMessageProperty)
         );
         session.setTrustedPackages(this.trustedPackages);
         this.sessions.add(session);

--- a/src/main/java/com/rabbitmq/jms/client/RMQConnection.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQConnection.java
@@ -10,22 +10,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.jms.Connection;
-import javax.jms.ConnectionConsumer;
-import javax.jms.ConnectionMetaData;
-import javax.jms.Destination;
-import javax.jms.ExceptionListener;
+import javax.jms.*;
 import javax.jms.IllegalStateException;
-import javax.jms.InvalidClientIDException;
-import javax.jms.JMSException;
-import javax.jms.Queue;
-import javax.jms.QueueConnection;
-import javax.jms.QueueSession;
-import javax.jms.ServerSessionPool;
-import javax.jms.Session;
-import javax.jms.Topic;
-import javax.jms.TopicConnection;
-import javax.jms.TopicSession;
 
 import com.rabbitmq.jms.util.WhiteListObjectInputStream;
 import org.slf4j.Logger;
@@ -91,6 +77,14 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
     private final int channelsQos;
 
     /**
+     * Whether {@link MessageProducer} properties (delivery mode,
+     * priority, TTL) take precedence over respective {@link Message}
+     * properties or not.
+     * Default is true.
+     */
+    private boolean messageProducerPropertyPrioritary;
+
+    /**
      * Classes in these packages can be transferred via ObjectMessage.
      *
      * @see WhiteListObjectInputStream
@@ -110,6 +104,7 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
         this.queueBrowserReadMax = connectionParams.getQueueBrowserReadMax();
         this.onMessageTimeoutMs = connectionParams.getOnMessageTimeoutMs();
         this.channelsQos = connectionParams.getChannelsQos();
+        this.messageProducerPropertyPrioritary = connectionParams.isMessageProducerPropertyPrioritary();
     }
 
     /**
@@ -155,6 +150,7 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
             .setOnMessageTimeoutMs(onMessageTimeoutMs)
             .setMode(acknowledgeMode)
             .setSubscriptions(this.subscriptions)
+            .setMessageProducerPropertyPrioritary(this.messageProducerPropertyPrioritary)
         );
         session.setTrustedPackages(this.trustedPackages);
         this.sessions.add(session);

--- a/src/main/java/com/rabbitmq/jms/client/RMQMessage.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQMessage.java
@@ -71,11 +71,15 @@ public abstract class RMQMessage implements Message, Cloneable {
     private static final String JMS_MESSAGE_CORR_ID = PREFIX + "jms.message.correlation.id";
     private static final String JMS_MESSAGE_REPLY_TO = PREFIX + "jms.message.reply.to";
     private static final String JMS_MESSAGE_DESTINATION = PREFIX + "jms.message.destination";
-    private static final String JMS_MESSAGE_DELIVERY_MODE = PREFIX + "jms.message.delivery.mode";
     private static final String JMS_MESSAGE_REDELIVERED = PREFIX + "jms.message.redelivered";
     private static final String JMS_MESSAGE_TYPE = PREFIX + "jms.message.type";
-    private static final String JMS_MESSAGE_EXPIRATION = PREFIX + "jms.message.expiration";
-    private static final String JMS_MESSAGE_PRIORITY = PREFIX + "jms.message.priority";
+
+    /**
+     * Those needs to be checked in the producer
+     */
+    static final String JMS_MESSAGE_DELIVERY_MODE = PREFIX + "jms.message.delivery.mode";
+    static final String JMS_MESSAGE_EXPIRATION = PREFIX + "jms.message.expiration";
+    static final String JMS_MESSAGE_PRIORITY = PREFIX + "jms.message.priority";
 
     /**
      * For turning {@link String}s into <code>byte[]</code> and back we use this {@link Charset} instance.

--- a/src/main/java/com/rabbitmq/jms/client/RMQMessageProducer.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQMessageProducer.java
@@ -73,15 +73,15 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
      * Create a producer of messages.
      * @param session which this producer uses
      * @param destination to which this producer sends messages.
-     * @param producerPropertyPrioritary properties take precedence over respective message properties
+     * @param preferProducerMessageProperty properties take precedence over respective message properties
      */
-    public RMQMessageProducer(RMQSession session, RMQDestination destination, boolean producerPropertyPrioritary) {
+    public RMQMessageProducer(RMQSession session, RMQDestination destination, boolean preferProducerMessageProperty) {
         this.session = session;
         this.destination = destination;
-        if (producerPropertyPrioritary) {
-            sendingStrategy = new MessageProducerPropertyPrioritarySendingStategy();
+        if (preferProducerMessageProperty) {
+            sendingStrategy = new PreferMessageProducerPropertySendingStategy();
         } else {
-            sendingStrategy = new MessagePropertyPrioritarySendingStrategy();
+            sendingStrategy = new PreferMessagePropertySendingStrategy();
         }
     }
 
@@ -422,7 +422,7 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
      * This implementation ignores message properties (delivery mode, priority, and expiration)
      * in favor of the message producer's properties.
      */
-    private class MessageProducerPropertyPrioritarySendingStategy implements SendingStrategy {
+    private class PreferMessageProducerPropertySendingStategy implements SendingStrategy {
 
         @Override
         public void send(Destination destination, Message message) throws JMSException {
@@ -440,7 +440,7 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
      * This implementation uses message properties (delivery mode, priority, and expiration)
      * if they've been set up. It falls back to the message producer's properties.
      */
-    private class MessagePropertyPrioritarySendingStrategy implements SendingStrategy {
+    private class PreferMessagePropertySendingStrategy implements SendingStrategy {
 
         @Override
         public void send(Destination destination, Message message) throws JMSException {

--- a/src/main/java/com/rabbitmq/jms/client/RMQSession.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQSession.java
@@ -85,7 +85,7 @@ public class RMQSession implements Session, QueueSession, TopicSession {
      * properties or not.
      * Default is true.
      */
-    private boolean messageProducerPropertyPrioritary = true;
+    private boolean preferProducerMessageProperty = true;
 
     /** The main RabbitMQ channel we use under the hood */
     private final Channel channel;
@@ -176,7 +176,7 @@ public class RMQSession implements Session, QueueSession, TopicSession {
         this.transacted = sessionParams.isTransacted();
         this.subscriptions = sessionParams.getSubscriptions();
         this.deliveryExecutor = new DeliveryExecutor(sessionParams.getOnMessageTimeoutMs());
-        this.messageProducerPropertyPrioritary = sessionParams.isMessageProducerPropertyPrioritary();
+        this.preferProducerMessageProperty = sessionParams.willPreferProducerMessageProperty();
 
         if (transacted) {
             this.acknowledgeMode = Session.SESSION_TRANSACTED;
@@ -586,7 +586,7 @@ public class RMQSession implements Session, QueueSession, TopicSession {
         illegalStateExceptionIfClosed();
         RMQDestination dest = (RMQDestination) destination;
         declareDestinationIfNecessary(dest);
-        RMQMessageProducer producer = new RMQMessageProducer(this, dest, this.messageProducerPropertyPrioritary);
+        RMQMessageProducer producer = new RMQMessageProducer(this, dest, this.preferProducerMessageProperty);
         this.producers.add(producer);
         return producer;
     }

--- a/src/main/java/com/rabbitmq/jms/client/RMQSession.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQSession.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2013, 2014 Pivotal Software, Inc. All rights reserved. */
+/* Copyright (c) 2013-2017 Pivotal Software, Inc. All rights reserved. */
 package com.rabbitmq.jms.client;
 
 import java.io.IOException;
@@ -78,6 +78,14 @@ public class RMQSession implements Session, QueueSession, TopicSession {
     private final int acknowledgeMode;
     /** Flag to remember if session is {@link #CLIENT_INDIVIDUAL_ACKNOWLEDGE} */
     private final boolean isIndividualAck;
+
+    /**
+     * Whether {@link MessageProducer} properties (delivery mode,
+     * priority, TTL) take precedence over respective {@link Message}
+     * properties or not.
+     * Default is true.
+     */
+    private boolean messageProducerPropertyPrioritary = true;
 
     /** The main RabbitMQ channel we use under the hood */
     private final Channel channel;
@@ -168,6 +176,7 @@ public class RMQSession implements Session, QueueSession, TopicSession {
         this.transacted = sessionParams.isTransacted();
         this.subscriptions = sessionParams.getSubscriptions();
         this.deliveryExecutor = new DeliveryExecutor(sessionParams.getOnMessageTimeoutMs());
+        this.messageProducerPropertyPrioritary = sessionParams.isMessageProducerPropertyPrioritary();
 
         if (transacted) {
             this.acknowledgeMode = Session.SESSION_TRANSACTED;
@@ -577,7 +586,7 @@ public class RMQSession implements Session, QueueSession, TopicSession {
         illegalStateExceptionIfClosed();
         RMQDestination dest = (RMQDestination) destination;
         declareDestinationIfNecessary(dest);
-        RMQMessageProducer producer = new RMQMessageProducer(this, dest);
+        RMQMessageProducer producer = new RMQMessageProducer(this, dest, this.messageProducerPropertyPrioritary);
         this.producers.add(producer);
         return producer;
     }

--- a/src/main/java/com/rabbitmq/jms/client/SessionParams.java
+++ b/src/main/java/com/rabbitmq/jms/client/SessionParams.java
@@ -1,6 +1,8 @@
-/* Copyright (c) 2016 Pivotal Software, Inc. All rights reserved. */
+/* Copyright (c) 2016-2017 Pivotal Software, Inc. All rights reserved. */
 package com.rabbitmq.jms.client;
 
+import javax.jms.Message;
+import javax.jms.MessageProducer;
 import java.util.Map;
 
 /**
@@ -22,6 +24,14 @@ public class SessionParams {
 
     /** List of durable subscriptions */
     private Map<String, RMQMessageConsumer> subscriptions;
+
+    /**
+     * Whether {@link MessageProducer} properties (delivery mode,
+     * priority, TTL) take precedence over respective {@link Message}
+     * properties or not.
+     * Default is true.
+     */
+    private boolean messageProducerPropertyPrioritary = true;
 
     public RMQConnection getConnection() {
         return connection;
@@ -65,6 +75,15 @@ public class SessionParams {
 
     public SessionParams setSubscriptions(Map<String, RMQMessageConsumer> subscriptions) {
         this.subscriptions = subscriptions;
+        return this;
+    }
+
+    public boolean isMessageProducerPropertyPrioritary() {
+        return messageProducerPropertyPrioritary;
+    }
+
+    public SessionParams setMessageProducerPropertyPrioritary(boolean messageProducerPropertyPrioritary) {
+        this.messageProducerPropertyPrioritary = messageProducerPropertyPrioritary;
         return this;
     }
 }

--- a/src/main/java/com/rabbitmq/jms/client/SessionParams.java
+++ b/src/main/java/com/rabbitmq/jms/client/SessionParams.java
@@ -31,7 +31,7 @@ public class SessionParams {
      * properties or not.
      * Default is true.
      */
-    private boolean messageProducerPropertyPrioritary = true;
+    private boolean preferProducerMessageProperty = true;
 
     public RMQConnection getConnection() {
         return connection;
@@ -78,12 +78,12 @@ public class SessionParams {
         return this;
     }
 
-    public boolean isMessageProducerPropertyPrioritary() {
-        return messageProducerPropertyPrioritary;
+    public boolean willPreferProducerMessageProperty() {
+        return preferProducerMessageProperty;
     }
 
-    public SessionParams setMessageProducerPropertyPrioritary(boolean messageProducerPropertyPrioritary) {
-        this.messageProducerPropertyPrioritary = messageProducerPropertyPrioritary;
+    public SessionParams setPreferProducerMessageProperty(boolean preferProducerMessageProperty) {
+        this.preferProducerMessageProperty = preferProducerMessageProperty;
         return this;
     }
 }

--- a/src/test/java/com/rabbitmq/jms/client/RMQMessageProducerTest.java
+++ b/src/test/java/com/rabbitmq/jms/client/RMQMessageProducerTest.java
@@ -29,7 +29,7 @@ public class RMQMessageProducerTest {
         destination = Mockito.mock(RMQDestination.class);
     }
 
-    @Test public void producerPropertyPrioritaryNoMessagePropertySpecified() throws Exception {
+    @Test public void preferProducerPropertyNoMessagePropertySpecified() throws Exception {
         StubRMQMessageProducer producer = new StubRMQMessageProducer(
             session, destination, true
         );
@@ -44,7 +44,7 @@ public class RMQMessageProducerTest {
         assertTrue(message.getJMSExpiration() > System.currentTimeMillis());
     }
 
-    @Test public void producerPropertyPrioritaryMessagePropertiesSpecified() throws Exception {
+    @Test public void preferProducerPropertyMessagePropertiesSpecified() throws Exception {
         StubRMQMessageProducer producer = new StubRMQMessageProducer(
             session, destination, true
         );
@@ -62,7 +62,7 @@ public class RMQMessageProducerTest {
         assertTrue(message.getJMSExpiration() > System.currentTimeMillis());
     }
 
-    @Test public void producerPropertyNotPrioritaryNoMessagePropertySpecified() throws Exception {
+    @Test public void preferMessagePropertyNoMessagePropertySpecified() throws Exception {
         StubRMQMessageProducer producer = new StubRMQMessageProducer(
             session, destination, false
         );
@@ -77,7 +77,7 @@ public class RMQMessageProducerTest {
         assertTrue(message.getJMSExpiration() > System.currentTimeMillis());
     }
 
-    @Test public void producerPropertyNotPrioritaryMessagePropertiesSpecified() throws Exception {
+    @Test public void preferMessagePropertyMessagePropertiesSpecified() throws Exception {
         StubRMQMessageProducer producer = new StubRMQMessageProducer(
             session, destination, false
         );
@@ -100,8 +100,8 @@ public class RMQMessageProducerTest {
 
         RMQMessage message;
 
-        public StubRMQMessageProducer(RMQSession session, RMQDestination destination, boolean producerPropertyPrioritary) {
-            super(session, destination, producerPropertyPrioritary);
+        public StubRMQMessageProducer(RMQSession session, RMQDestination destination, boolean preferProducerMessageProperty) {
+            super(session, destination, preferProducerMessageProperty);
         }
 
         @Override

--- a/src/test/java/com/rabbitmq/jms/client/RMQMessageProducerTest.java
+++ b/src/test/java/com/rabbitmq/jms/client/RMQMessageProducerTest.java
@@ -1,0 +1,113 @@
+/* Copyright (c) 2017 Pivotal Software, Inc. All rights reserved. */
+package com.rabbitmq.jms.client;
+
+import com.rabbitmq.jms.admin.RMQDestination;
+import com.rabbitmq.jms.client.message.RMQTextMessage;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import javax.jms.DeliveryMode;
+import javax.jms.JMSException;
+import javax.jms.Message;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ *
+ */
+public class RMQMessageProducerTest {
+
+    RMQSession session;
+    RMQDestination destination;
+
+    @Before public void init() {
+        session = Mockito.mock(RMQSession.class);
+        destination = Mockito.mock(RMQDestination.class);
+    }
+
+    @Test public void producerPropertyPrioritaryNoMessagePropertySpecified() throws Exception {
+        StubRMQMessageProducer producer = new StubRMQMessageProducer(
+            session, destination, true
+        );
+        producer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+        producer.setPriority(9);
+        producer.setTimeToLive(1000L);
+        RMQTextMessage message = new RMQTextMessage();
+        producer.send(message);
+
+        assertEquals(DeliveryMode.NON_PERSISTENT, message.getJMSDeliveryMode());
+        assertEquals(9, message.getJMSPriority());
+        assertTrue(message.getJMSExpiration() > System.currentTimeMillis());
+    }
+
+    @Test public void producerPropertyPrioritaryMessagePropertiesSpecified() throws Exception {
+        StubRMQMessageProducer producer = new StubRMQMessageProducer(
+            session, destination, true
+        );
+        producer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+        producer.setPriority(9);
+        producer.setTimeToLive(1000L);
+        RMQTextMessage message = new RMQTextMessage();
+        message.setJMSPriority(1);
+        message.setJMSDeliveryMode(DeliveryMode.PERSISTENT);
+        message.setJMSExpiration(System.currentTimeMillis() + 10 * 1000);
+        producer.send(message);
+
+        assertEquals(DeliveryMode.NON_PERSISTENT, message.getJMSDeliveryMode());
+        assertEquals(9, message.getJMSPriority());
+        assertTrue(message.getJMSExpiration() > System.currentTimeMillis());
+    }
+
+    @Test public void producerPropertyNotPrioritaryNoMessagePropertySpecified() throws Exception {
+        StubRMQMessageProducer producer = new StubRMQMessageProducer(
+            session, destination, false
+        );
+        producer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+        producer.setPriority(9);
+        producer.setTimeToLive(1000L);
+        RMQTextMessage message = new RMQTextMessage();
+        producer.send(message);
+
+        assertEquals(DeliveryMode.NON_PERSISTENT, message.getJMSDeliveryMode());
+        assertEquals(9, message.getJMSPriority());
+        assertTrue(message.getJMSExpiration() > System.currentTimeMillis());
+    }
+
+    @Test public void producerPropertyNotPrioritaryMessagePropertiesSpecified() throws Exception {
+        StubRMQMessageProducer producer = new StubRMQMessageProducer(
+            session, destination, false
+        );
+        producer.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+        producer.setPriority(9);
+        producer.setTimeToLive(1000L);
+        RMQTextMessage message = new RMQTextMessage();
+        message.setJMSPriority(1);
+        message.setJMSDeliveryMode(DeliveryMode.PERSISTENT);
+        long expiration = System.currentTimeMillis() + 10 * 1000;
+        message.setJMSExpiration(expiration);
+        producer.send(message);
+
+        assertEquals(DeliveryMode.PERSISTENT, message.getJMSDeliveryMode());
+        assertEquals(1, message.getJMSPriority());
+        assertEquals(expiration, message.getJMSExpiration());
+    }
+
+    static class StubRMQMessageProducer extends RMQMessageProducer {
+
+        RMQMessage message;
+
+        public StubRMQMessageProducer(RMQSession session, RMQDestination destination, boolean producerPropertyPrioritary) {
+            super(session, destination, producerPropertyPrioritary);
+        }
+
+        @Override
+        protected void sendJMSMessage(RMQDestination destination, RMQMessage msg, int deliveryMode, int priority, long timeToLive) throws JMSException {
+            this.message = msg;
+        }
+    }
+
+}


### PR DESCRIPTION
Priority, delivery mode, and expiration aren't taken into
account on sending when set in the JMS message. This is compliant with
the specifiation though. This commit provide a flag in
RMQConnectionFactory to make the RMQMessageProducer use the
message properties if set. This is non-compliant with the specification
but more natural. The existing and spec-compliant behavior is still
the default.

Fixes #26