### PR TITLE
Add option to requeue message on client runtime exception

### DIFF
--- a/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
@@ -56,6 +56,13 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
      */
     private boolean preferProducerMessageProperty = true;
 
+    /**
+     * Whether requeue message on {@link RuntimeException} in the
+     * {@link javax.jms.MessageListener} or not.
+     * Default is false.
+     */
+    private boolean requeueOnMessageListenerException = false;
+
     /** Default not to use ssl */
     private boolean ssl = false;
     private String tlsProtocol;
@@ -116,6 +123,7 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
             .setOnMessageTimeoutMs(getOnMessageTimeoutMs())
             .setChannelsQos(channelsQos)
             .setPreferProducerMessageProperty(preferProducerMessageProperty)
+            .setRequeueOnMessageListenerException(requeueOnMessageListenerException)
         );
         conn.setTrustedPackages(this.trustedPackages);
         logger.debug("Connection {} created.", conn);
@@ -138,6 +146,7 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
             .setOnMessageTimeoutMs(getOnMessageTimeoutMs())
             .setChannelsQos(channelsQos)
             .setPreferProducerMessageProperty(preferProducerMessageProperty)
+            .setRequeueOnMessageListenerException(requeueOnMessageListenerException)
         );
         conn.setTrustedPackages(this.trustedPackages);
         logger.debug("Connection {} created.", conn);
@@ -652,4 +661,18 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
     public boolean isPreferProducerMessageProperty() {
         return preferProducerMessageProperty;
     }
+
+    /**
+     * Whether requeue message on {@link RuntimeException} in the
+     * {@link javax.jms.MessageListener} or not.
+     * Default is false.
+     */
+    public void setRequeueOnMessageListenerException(boolean requeueOnMessageListenerException) {
+        this.requeueOnMessageListenerException = requeueOnMessageListenerException;
+    }
+
+    public boolean isRequeueOnMessageListenerException() {
+        return requeueOnMessageListenerException;
+    }
 }
+

--- a/src/main/java/com/rabbitmq/jms/client/ConnectionParams.java
+++ b/src/main/java/com/rabbitmq/jms/client/ConnectionParams.java
@@ -38,6 +38,13 @@ public class ConnectionParams {
      */
     private boolean preferProducerMessageProperty = true;
 
+    /**
+     * Whether requeue message on {@link RuntimeException} in the
+     * {@link javax.jms.MessageListener} or not.
+     * Default is false.
+     */
+    private boolean requeueOnMessageListenerException = false;
+
     public Connection getRabbitConnection() {
         return rabbitConnection;
     }
@@ -89,6 +96,15 @@ public class ConnectionParams {
 
     public ConnectionParams setPreferProducerMessageProperty(boolean preferProducerMessageProperty) {
         this.preferProducerMessageProperty = preferProducerMessageProperty;
+        return this;
+    }
+
+    public boolean willRequeueOnMessageListenerException() {
+        return requeueOnMessageListenerException;
+    }
+
+    public ConnectionParams setRequeueOnMessageListenerException(boolean requeueOnMessageListenerException) {
+        this.requeueOnMessageListenerException = requeueOnMessageListenerException;
         return this;
     }
 }

--- a/src/main/java/com/rabbitmq/jms/client/DeliveryExecutor.java
+++ b/src/main/java/com/rabbitmq/jms/client/DeliveryExecutor.java
@@ -64,7 +64,7 @@ public class DeliveryExecutor {
             this.closeAbruptly();
             throw new RMQJMSException("onMessage took too long and was interrupted", null);
         } catch (ExecutionException e) {
-            throw new RMQJMSException("onMessage threw exception", e.getCause());
+            throw new RMQMessageListenerExecutionJMSException("onMessage threw exception", e.getCause());
         }
     }
 

--- a/src/main/java/com/rabbitmq/jms/client/RMQConnection.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQConnection.java
@@ -85,6 +85,13 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
     private boolean preferProducerMessageProperty;
 
     /**
+     * Whether requeue message on {@link RuntimeException} in the
+     * {@link javax.jms.MessageListener} or not.
+     * Default is false.
+     */
+    private boolean requeueOnMessageListenerException;
+
+    /**
      * Classes in these packages can be transferred via ObjectMessage.
      *
      * @see WhiteListObjectInputStream
@@ -105,6 +112,7 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
         this.onMessageTimeoutMs = connectionParams.getOnMessageTimeoutMs();
         this.channelsQos = connectionParams.getChannelsQos();
         this.preferProducerMessageProperty = connectionParams.willPreferProducerMessageProperty();
+        this.requeueOnMessageListenerException = connectionParams.willRequeueOnMessageListenerException();
     }
 
     /**
@@ -151,6 +159,7 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
             .setMode(acknowledgeMode)
             .setSubscriptions(this.subscriptions)
             .setPreferProducerMessageProperty(this.preferProducerMessageProperty)
+            .setRequeueOnMessageListenerException(this.requeueOnMessageListenerException)
         );
         session.setTrustedPackages(this.trustedPackages);
         this.sessions.add(session);

--- a/src/main/java/com/rabbitmq/jms/client/RMQMessageListenerExecutionJMSException.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQMessageListenerExecutionJMSException.java
@@ -1,0 +1,27 @@
+/* Copyright (c) 2017 Pivotal Software, Inc. All rights reserved. */
+package com.rabbitmq.jms.client;
+
+import javax.jms.JMSException;
+
+/**
+ * Wraps an execution exception as a {@link JMSException}.
+ */
+public class RMQMessageListenerExecutionJMSException extends JMSException {
+
+    /** Default version ID */
+    private static final long serialVersionUID = 1L;
+
+    public RMQMessageListenerExecutionJMSException(String msg, Throwable x) {
+        this(msg, null, x);
+    }
+
+    public RMQMessageListenerExecutionJMSException(Throwable x) {
+        this(x.getMessage(), x);
+    }
+
+    private RMQMessageListenerExecutionJMSException(String msg, String errorCode, Throwable x) {
+        super(msg, errorCode);
+        this.initCause(x);
+    }
+
+}

--- a/src/main/java/com/rabbitmq/jms/client/RMQSession.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQSession.java
@@ -87,6 +87,13 @@ public class RMQSession implements Session, QueueSession, TopicSession {
      */
     private boolean preferProducerMessageProperty = true;
 
+    /**
+     * Whether requeue message on {@link RuntimeException} in the
+     * {@link javax.jms.MessageListener} or not.
+     * Default is false.
+     */
+    private boolean requeueOnMessageListenerException = false;
+
     /** The main RabbitMQ channel we use under the hood */
     private final Channel channel;
     /** Set to true if close() has been called and completed */
@@ -177,6 +184,7 @@ public class RMQSession implements Session, QueueSession, TopicSession {
         this.subscriptions = sessionParams.getSubscriptions();
         this.deliveryExecutor = new DeliveryExecutor(sessionParams.getOnMessageTimeoutMs());
         this.preferProducerMessageProperty = sessionParams.willPreferProducerMessageProperty();
+        this.requeueOnMessageListenerException = sessionParams.willRequeueOnMessageListenerException();
 
         if (transacted) {
             this.acknowledgeMode = Session.SESSION_TRANSACTED;
@@ -663,7 +671,7 @@ public class RMQSession implements Session, QueueSession, TopicSession {
                 throw new RMQJMSException("RabbitMQ Exception creating Consumer", x);
             }
         }
-        RMQMessageConsumer consumer = new RMQMessageConsumer(this, dest, consumerTag, getConnection().isStopped(), jmsSelector);
+        RMQMessageConsumer consumer = new RMQMessageConsumer(this, dest, consumerTag, getConnection().isStopped(), jmsSelector, this.requeueOnMessageListenerException);
         this.consumers.add(consumer);
         return consumer;
     }

--- a/src/main/java/com/rabbitmq/jms/client/SessionParams.java
+++ b/src/main/java/com/rabbitmq/jms/client/SessionParams.java
@@ -33,6 +33,13 @@ public class SessionParams {
      */
     private boolean preferProducerMessageProperty = true;
 
+    /**
+     * Whether requeue message on {@link RuntimeException} in the
+     * {@link javax.jms.MessageListener} or not.
+     * Default is false.
+     */
+    private boolean requeueOnMessageListenerException = false;
+
     public RMQConnection getConnection() {
         return connection;
     }
@@ -84,6 +91,15 @@ public class SessionParams {
 
     public SessionParams setPreferProducerMessageProperty(boolean preferProducerMessageProperty) {
         this.preferProducerMessageProperty = preferProducerMessageProperty;
+        return this;
+    }
+
+    public boolean willRequeueOnMessageListenerException() {
+        return requeueOnMessageListenerException;
+    }
+
+    public SessionParams setRequeueOnMessageListenerException(boolean requeueOnMessageListenerException) {
+        this.requeueOnMessageListenerException = requeueOnMessageListenerException;
         return this;
     }
 }

--- a/src/test/java/com/rabbitmq/integration/tests/RequeueMessageOnListenerExceptionIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/RequeueMessageOnListenerExceptionIT.java
@@ -1,0 +1,125 @@
+/* Copyright (c) 2017 Pivotal Software, Inc. All rights reserved. */
+package com.rabbitmq.integration.tests;
+
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.jms.admin.RMQConnectionFactory;
+import com.rabbitmq.jms.client.RMQConnection;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.jms.*;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.*;
+
+/**
+ *
+ */
+public class RequeueMessageOnListenerExceptionIT extends AbstractITQueue {
+    private static final String QUEUE_NAME = "test.queue." + RequeueMessageOnListenerExceptionIT.class.getCanonicalName();
+    private static final String MESSAGE = "Hello " + RequeueMessageOnListenerExceptionIT.class.getName();
+
+    @Before public void init() throws Exception {
+        Connection connection = null;
+        try {
+            com.rabbitmq.client.ConnectionFactory connectionFactory = new ConnectionFactory();
+            connection = connectionFactory.newConnection();
+            connection.createChannel().queueDelete(QUEUE_NAME);
+        } finally {
+            if (connection  != null) {
+                connection.close();
+            }
+        }
+
+
+    }
+
+    @Test
+    public void requeueParameterTrueRuntimeExceptionInListenerMessageShouldBeNacked() throws Exception {
+        sendMessage();
+        QueueConnection connection = null;
+        try {
+            connection = connection(RMQConnection.NO_CHANNEL_QOS);
+            QueueSession queueSession = connection.createQueueSession(false, Session.AUTO_ACKNOWLEDGE);
+            Queue queue = queueSession.createQueue(QUEUE_NAME);
+            QueueReceiver queueReceiver = queueSession.createReceiver(queue);
+            final CountDownLatch latch = new CountDownLatch(1);
+            queueReceiver.setMessageListener(new MessageListener() {
+                @Override
+                public void onMessage(Message message) {
+                    if (true) {
+                        latch.countDown();
+                        throw new RuntimeException("runtime exception in message listener");
+                    }
+                }
+            });
+
+            // another consumer can consume the message
+            queueSession = connection.createQueueSession(false, Session.AUTO_ACKNOWLEDGE);
+            queueReceiver = queueSession.createReceiver(queue);
+            Message message = queueReceiver.receive(1000L);
+            assertNotNull(message);
+            assertTrue(message.getJMSRedelivered());
+        } finally {
+            if(connection != null) {
+                connection.close();
+            }
+        }
+    }
+
+    @Test
+    public void requeueParameterTrueNoExceptionInListenerQueueShouldBeEmpty() throws Exception {
+        sendMessage();
+        QueueConnection connection = null;
+        try {
+            connection = connection(RMQConnection.NO_CHANNEL_QOS);
+            QueueSession queueSession = connection.createQueueSession(false, Session.AUTO_ACKNOWLEDGE);
+            Queue queue = queueSession.createQueue(QUEUE_NAME);
+            QueueReceiver queueReceiver = queueSession.createReceiver(queue);
+            final CountDownLatch latch = new CountDownLatch(1);
+            queueReceiver.setMessageListener(new MessageListener() {
+                @Override
+                public void onMessage(Message message) {
+                    latch.countDown();
+                }
+            });
+
+            // the message has been consumed, no longer in the queue
+            queueSession = connection.createQueueSession(false, Session.AUTO_ACKNOWLEDGE);
+            queueReceiver = queueSession.createReceiver(queue);
+            Message message = queueReceiver.receive(1000L);
+            assertNull(message);
+        } finally {
+            if(connection != null) {
+                connection.close();
+            }
+        }
+    }
+
+    private void sendMessage() throws Exception {
+        try {
+            queueConn.start();
+            QueueSession queueSession = queueConn.createQueueSession(false, Session.CLIENT_ACKNOWLEDGE);
+            Queue queue = queueSession.createQueue(QUEUE_NAME);
+            QueueSender queueSender = queueSession.createSender(queue);
+            queueSender.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+            TextMessage message = queueSession.createTextMessage(MESSAGE);
+            queueSender.send(message);
+        } finally {
+            reconnect();
+        }
+    }
+
+    private QueueConnection connection(int qos) throws Exception {
+        RMQConnectionFactory connectionFactory = (RMQConnectionFactory) AbstractTestConnectionFactory.getTestConnectionFactory().getConnectionFactory();
+        connectionFactory.setChannelsQos(qos);
+        connectionFactory.setRequeueOnMessageListenerException(true);
+        QueueConnection queueConnection = connectionFactory.createQueueConnection();
+        queueConnection.start();
+        return queueConnection;
+    }
+
+
+
+}


### PR DESCRIPTION
Requeuing a message after a client RuntimeException complies to
the JMS specification. Nevertheless, the default behavior is
still the same: the message is "lost" (as it has been AMQP-acknowledged
before the delivery to the client) if the client fails to process
it (which makes more sense to us).

The option is RMQConnectionFactory#requeueOnMessageListenerException
and is false by default.

Fixes #23