### PR TITLE
set the auto-delete to true for broker queues created to support non-…

### DIFF
--- a/src/main/java/com/rabbitmq/jms/client/RMQSession.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQSession.java
@@ -822,7 +822,10 @@ public class RMQSession implements Session, QueueSession, TopicSession {
             this.channel.queueDeclare(queueName,
                                       durable,
                                       exclusive,
-                                      false,    // autoDelete - exclusive takes care of this
+                                      /* broker queues declared for a non-durable topic that have an auto-generated name must go down with
+                                         consumer/producer or the broker will leak them until the connection is brought down
+                                       */ 
+                                      !durable && queueNameOverride != null && !dest.isQueue(), // autoDelete
                                       options); // object properties
 
             /* Temporary or 'topic queues' are exclusive and therefore get deleted by RabbitMQ on close */


### PR DESCRIPTION
…durable topics with autogenerated names

Broker queues defined for Topic consumers of non-durable Topics are assigned auto-generated names that are not visible to JMS clients.

These broker queues are inherently transient and were previously (correctly) unbounded when the connection to the broker was closed.  However, because these broker queues are created per consumer, the broker would effectively leak these until the connection was closed.

This change flags such broker queues with the auto-delete flag, enabling the broker to expunge them once the last consumer is closed.