### PR TITLE
Add callback before sending message

### DIFF
--- a/src/main/java/com/rabbitmq/jms/client/ConnectionParams.java
+++ b/src/main/java/com/rabbitmq/jms/client/ConnectionParams.java
@@ -52,15 +52,24 @@ public class ConnectionParams {
      * If set to true, those queues will be deleted when the session is closed.
      * If set to false, queues will be deleted when the owning connection is closed.
      * Default is false.
+     *
      * @since 1.8.0
      */
     private boolean cleanUpServerNamedQueuesForNonDurableTopicsOnSessionClose = false;
 
     /**
      * Callback to customise properties of outbound AMQP messages.
+     *
      * @since 1.9.0
      */
     private BiFunction<AMQP.BasicProperties.Builder, Message, AMQP.BasicProperties.Builder> amqpPropertiesCustomiser;
+
+    /**
+     * Callback before sending a message.
+     *
+     * @since 1.11.0
+     */
+    private SendingContextConsumer sendingContextConsumer;
 
     public Connection getRabbitConnection() {
         return rabbitConnection;
@@ -140,6 +149,15 @@ public class ConnectionParams {
 
     public ConnectionParams setAmqpPropertiesCustomiser(BiFunction<AMQP.BasicProperties.Builder, Message, AMQP.BasicProperties.Builder> amqpPropertiesCustomiser) {
         this.amqpPropertiesCustomiser = amqpPropertiesCustomiser;
+        return this;
+    }
+
+    public SendingContextConsumer getSendingContextConsumer() {
+        return sendingContextConsumer;
+    }
+
+    public ConnectionParams setSendingContextConsumer(SendingContextConsumer sendingContextConsumer) {
+        this.sendingContextConsumer = sendingContextConsumer;
         return this;
     }
 }

--- a/src/main/java/com/rabbitmq/jms/client/RMQConnection.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQConnection.java
@@ -104,9 +104,17 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
 
     /**
      * Callback to customise properties of outbound AMQP messages.
+     *
      * @since 1.9.0
      */
     private final BiFunction<AMQP.BasicProperties.Builder, Message, AMQP.BasicProperties.Builder> amqpPropertiesCustomiser;
+
+    /**
+     * Callback before sending a message.
+     *
+     * @since 1.11.0
+     */
+    private final SendingContextConsumer sendingContextConsumer;
 
     /**
      * Classes in these packages can be transferred via ObjectMessage.
@@ -132,6 +140,7 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
         this.requeueOnMessageListenerException = connectionParams.willRequeueOnMessageListenerException();
         this.cleanUpServerNamedQueuesForNonDurableTopicsOnSessionClose = connectionParams.isCleanUpServerNamedQueuesForNonDurableTopicsOnSessionClose();
         this.amqpPropertiesCustomiser = connectionParams.getAmqpPropertiesCustomiser();
+        this.sendingContextConsumer = connectionParams.getSendingContextConsumer();
     }
 
     /**
@@ -181,6 +190,7 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
             .setRequeueOnMessageListenerException(this.requeueOnMessageListenerException)
             .setCleanUpServerNamedQueuesForNonDurableTopics(this.cleanUpServerNamedQueuesForNonDurableTopicsOnSessionClose)
             .setAmqpPropertiesCustomiser(this.amqpPropertiesCustomiser)
+            .setSendingContextConsumer(this.sendingContextConsumer)
         );
         session.setTrustedPackages(this.trustedPackages);
         this.sessions.add(session);

--- a/src/main/java/com/rabbitmq/jms/client/SendingContext.java
+++ b/src/main/java/com/rabbitmq/jms/client/SendingContext.java
@@ -1,0 +1,33 @@
+/* Copyright (c) 2018 Pivotal Software, Inc. All rights reserved. */
+
+package com.rabbitmq.jms.client;
+
+import javax.jms.Destination;
+import javax.jms.Message;
+
+/**
+ * Context when sending message.
+ *
+ * @see com.rabbitmq.jms.admin.RMQConnectionFactory#setSendingContextConsumer(SendingContextConsumer)
+ * @see SendingContextConsumer
+ * @since 1.11.0
+ */
+public class SendingContext {
+
+    private final Message message;
+
+    private final Destination destination;
+
+    public SendingContext(Destination destination, Message message) {
+        this.destination = destination;
+        this.message = message;
+    }
+
+    public Destination getDestination() {
+        return destination;
+    }
+
+    public Message getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/rabbitmq/jms/client/SendingContextConsumer.java
+++ b/src/main/java/com/rabbitmq/jms/client/SendingContextConsumer.java
@@ -1,0 +1,43 @@
+package com.rabbitmq.jms.client;
+
+import javax.jms.JMSException;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+/**
+ * Callback before sending a message.
+ *
+ * @see com.rabbitmq.jms.admin.RMQConnectionFactory#setSendingContextConsumer(SendingContextConsumer)
+ * @see SendingContext
+ * @since 1.11.0
+ */
+@FunctionalInterface
+public interface SendingContextConsumer {
+
+    /**
+     * Called before sending a message.
+     * <p>
+     * Can be used to customize the message or the destination
+     * before the message is actually sent.
+     *
+     * @param sendingContext
+     * @throws JMSException
+     */
+    void accept(SendingContext sendingContext) throws JMSException;
+
+    /**
+     * Same semantics as {@link Consumer#andThen(Consumer)}.
+     *
+     * @param after the operation to perform after this operation
+     * @return a composed {@code SendingContextConsumer} that performs in sequence this
+     * operation followed by the {@code after} operation
+     * @throws NullPointerException if {@code after} is null
+     */
+    default SendingContextConsumer andThen(SendingContextConsumer after) {
+        Objects.requireNonNull(after);
+        return (SendingContext ctx) -> {
+            accept(ctx);
+            after.accept(ctx);
+        };
+    }
+}

--- a/src/main/java/com/rabbitmq/jms/client/SessionParams.java
+++ b/src/main/java/com/rabbitmq/jms/client/SessionParams.java
@@ -48,15 +48,24 @@ public class SessionParams {
      * If set to true, those queues will be deleted when the session is closed.
      * If set to false, queues will be deleted when the owning connection is closed.
      * Default is false.
+     *
      * @since 1.8.0
      */
     private boolean cleanUpServerNamedQueuesForNonDurableTopics = false;
 
     /**
      * Callback to customise properties of outbound AMQP messages.
+     *
      * @since 1.9.0
      */
     private BiFunction<AMQP.BasicProperties.Builder, Message, AMQP.BasicProperties.Builder> amqpPropertiesCustomiser;
+
+    /**
+     * Callback before sending a message.
+     *
+     * @since 1.11.0
+     */
+    private SendingContextConsumer sendingContextConsumer;
 
     public RMQConnection getConnection() {
         return connection;
@@ -137,5 +146,14 @@ public class SessionParams {
     public SessionParams setAmqpPropertiesCustomiser(BiFunction<AMQP.BasicProperties.Builder, Message, AMQP.BasicProperties.Builder> amqpPropertiesCustomiser) {
         this.amqpPropertiesCustomiser = amqpPropertiesCustomiser;
         return this;
+    }
+
+    public SessionParams setSendingContextConsumer(SendingContextConsumer sendingContextConsumer) {
+        this.sendingContextConsumer = sendingContextConsumer;
+        return this;
+    }
+
+    public SendingContextConsumer getSendingContextConsumer() {
+        return sendingContextConsumer;
     }
 }

--- a/src/test/java/com/rabbitmq/integration/tests/RpcIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/RpcIT.java
@@ -1,0 +1,173 @@
+/* Copyright (c) 2018 Pivotal Software, Inc. All rights reserved. */
+package com.rabbitmq.integration.tests;
+
+import com.rabbitmq.jms.admin.RMQConnectionFactory;
+import com.rabbitmq.jms.admin.RMQDestination;
+import com.rabbitmq.jms.client.SendingContextConsumer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ *
+ */
+public class RpcIT {
+
+    private static final String QUEUE_NAME = "test.queue." + RpcIT.class.getCanonicalName();
+    private static final Logger LOGGER = LoggerFactory.getLogger(RpcIT.class);
+
+    Connection serverConnection, clientConnection;
+
+    RpcServer rpcServer;
+
+    protected static void drainQueue(Session session, Queue queue) throws Exception {
+        MessageConsumer receiver = session.createConsumer(queue);
+        Message msg = receiver.receiveNoWait();
+        while (msg != null) {
+            msg = receiver.receiveNoWait();
+        }
+    }
+
+    static SendingContextConsumer destinationAlreadyDeclaredForRpcResponse() {
+        return ctx -> {
+            if (ctx.getMessage().getJMSCorrelationID() != null && ctx.getDestination() instanceof RMQDestination) {
+                RMQDestination destination = (RMQDestination) ctx.getDestination();
+                destination.setDeclared(true);
+            }
+        };
+    }
+
+    @BeforeEach
+    public void init() throws Exception {
+        ConnectionFactory connectionFactory = AbstractTestConnectionFactory.getTestConnectionFactory()
+            .getConnectionFactory();
+        clientConnection = connectionFactory.createConnection();
+        clientConnection.start();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        rpcServer.close();
+        if (clientConnection != null) {
+            clientConnection.close();
+        }
+        if (serverConnection != null) {
+            serverConnection.close();
+        }
+        com.rabbitmq.client.ConnectionFactory cf = new com.rabbitmq.client.ConnectionFactory();
+        try (com.rabbitmq.client.Connection c = cf.newConnection()) {
+            c.createChannel().queueDelete(QUEUE_NAME);
+        }
+    }
+
+    @Test
+    public void noResponseWhenServerTriesToRecreateTemporaryResponseQueue() throws Exception {
+        setupRpcServer();
+
+        String messageContent = UUID.randomUUID().toString();
+        Message response = doRpc(messageContent);
+        assertNull(response);
+    }
+
+    @Test
+    public void responseOkWhenServerDoesNotRecreateTemporaryResponseQueue() throws Exception {
+        setupRpcServer(destinationAlreadyDeclaredForRpcResponse());
+
+        String messageContent = UUID.randomUUID().toString();
+        Message response = doRpc(messageContent);
+        assertNotNull(response);
+        assertThat(response, is(instanceOf(TextMessage.class)));
+        assertThat(((TextMessage) response).getText(), is("*** " + messageContent + " ***"));
+    }
+
+    Message doRpc(String messageContent) throws Exception {
+        Session session = clientConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        TextMessage message = session.createTextMessage(messageContent);
+        message.setJMSCorrelationID(messageContent);
+
+        Destination replyQueue = session.createTemporaryQueue();
+        MessageProducer producer = session.createProducer(session.createQueue(QUEUE_NAME));
+
+        MessageConsumer responseConsumer = session.createConsumer(replyQueue);
+        BlockingQueue<Message> queue = new ArrayBlockingQueue<>(1);
+        responseConsumer.setMessageListener(msg -> queue.add(msg));
+        message.setJMSReplyTo(replyQueue);
+        producer.send(message);
+        return queue.poll(2, TimeUnit.SECONDS);
+    }
+
+    void setupRpcServer(SendingContextConsumer sendingContextConsumer) throws Exception {
+        RMQConnectionFactory connectionFactory = (RMQConnectionFactory) AbstractTestConnectionFactory.getTestConnectionFactory()
+            .getConnectionFactory();
+        connectionFactory.setSendingContextConsumer(sendingContextConsumer);
+        serverConnection = connectionFactory.createConnection();
+        serverConnection.start();
+        Session session = serverConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        Queue queue = session.createQueue(QUEUE_NAME);
+        drainQueue(session, queue);
+        session.close();
+        rpcServer = new RpcServer(serverConnection);
+    }
+
+    void setupRpcServer() throws Exception {
+        setupRpcServer(ctx -> {
+        });
+    }
+
+    private static class RpcServer {
+
+        Session session;
+
+        public RpcServer(Connection connection) throws JMSException {
+            session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+            Destination destination = session.createQueue(QUEUE_NAME);
+            MessageProducer replyProducer = session.createProducer(null);
+            MessageConsumer consumer = session.createConsumer(destination);
+            consumer.setMessageListener(msg -> {
+                TextMessage message = (TextMessage) msg;
+                try {
+                    String text = message.getText();
+                    Destination replyQueue = message.getJMSReplyTo();
+                    if (replyQueue != null) {
+                        TextMessage replyMessage = session.createTextMessage("*** " + text + " ***");
+                        replyMessage.setJMSCorrelationID(message.getJMSCorrelationID());
+                        replyProducer.send(replyQueue, replyMessage);
+                    }
+                } catch (JMSException e) {
+                    LOGGER.warn("Error in RPC server", e);
+                }
+            });
+        }
+
+        void close() {
+            try {
+                session.close();
+            } catch (Exception e) {
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
This allows changing/checking the destination and the message before
sending. This can be used to avoid creating a destination by calling
setDeclared(true) on it (useful for RPC on temporary queues).

Fixes #47