### PR TITLE
Handle request-reply with RabbitMQ direct reply-to

### DIFF
--- a/src/main/java/com/rabbitmq/jms/client/RMQMessageProducer.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQMessageProducer.java
@@ -1,8 +1,13 @@
 /* Copyright (c) 2013-2018 Pivotal Software, Inc. All rights reserved. */
 package com.rabbitmq.jms.client;
 
-import java.io.IOException;
-import java.util.function.BiFunction;
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.jms.admin.RMQDestination;
+import com.rabbitmq.jms.client.message.RMQBytesMessage;
+import com.rabbitmq.jms.client.message.RMQTextMessage;
+import com.rabbitmq.jms.util.RMQJMSException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.jms.Destination;
 import javax.jms.InvalidDestinationException;
@@ -13,15 +18,8 @@ import javax.jms.Queue;
 import javax.jms.QueueSender;
 import javax.jms.Topic;
 import javax.jms.TopicPublisher;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.rabbitmq.client.AMQP;
-import com.rabbitmq.jms.admin.RMQDestination;
-import com.rabbitmq.jms.client.message.RMQBytesMessage;
-import com.rabbitmq.jms.client.message.RMQTextMessage;
-import com.rabbitmq.jms.util.RMQJMSException;
+import java.io.IOException;
+import java.util.function.BiFunction;
 
 import static com.rabbitmq.jms.client.RMQMessage.JMS_MESSAGE_DELIVERY_MODE;
 import static com.rabbitmq.jms.client.RMQMessage.JMS_MESSAGE_EXPIRATION;
@@ -33,6 +31,8 @@ import static com.rabbitmq.jms.client.RMQMessage.JMS_MESSAGE_PRIORITY;
 public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPublisher {
 
     private final Logger logger = LoggerFactory.getLogger(RMQMessageProducer.class);
+
+    private static final String DIRECT_REPLY_TO = "amq.rabbitmq.reply-to";
 
     /**
      * The destination that we send our message to
@@ -312,6 +312,8 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
                 bob.expiration(rmqExpiration(timeToLive));
                 bob.headers(msg.toAmqpHeaders());
 
+                maybeSetReplyToPropertyToDirectReplyTo(bob, msg);
+
                 bob = amqpPropertiesCustomiser.apply(bob, msg);
 
                 byte[] data = msg.toAmqpByteArray();
@@ -337,11 +339,36 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
             bob.expiration(rmqExpiration(timeToLive));
             bob.headers(msg.toHeaders());
 
+            maybeSetReplyToPropertyToDirectReplyTo(bob, msg);
+
             byte[] data = msg.toByteArray();
 
             this.session.getChannel().basicPublish(destination.getAmqpExchangeName(), destination.getAmqpRoutingKey(), bob.build(), data);
         } catch (IOException x) {
             throw new RMQJMSException(x);
+        }
+    }
+
+    /**
+     * Set AMQP reply-to property to direct-reply-to if necessary.
+     * <p>
+     * Set the <code>reply-to</code> property to <code>amq.rabbitmq.reply-to</code>
+     * if the <code>JMSReplyTo</code> header is set to a destination with that
+     * name.
+     * <p>
+     * For outbound RPC request.
+     *
+     * @param builder
+     * @param msg
+     * @throws JMSException
+     * @since 1.11.0
+     */
+    private static void maybeSetReplyToPropertyToDirectReplyTo(AMQP.BasicProperties.Builder builder, RMQMessage msg) throws JMSException {
+        if (msg.getJMSReplyTo() != null && msg.getJMSReplyTo() instanceof RMQDestination) {
+            RMQDestination replyTo = (RMQDestination) msg.getJMSReplyTo();
+            if (DIRECT_REPLY_TO.equals(replyTo.getDestinationName())) {
+                builder.replyTo(DIRECT_REPLY_TO);
+            }
         }
     }
 

--- a/src/test/java/com/rabbitmq/integration/tests/RpcWithAmqpDirectReplyIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/RpcWithAmqpDirectReplyIT.java
@@ -1,0 +1,163 @@
+/* Copyright (c) 2018 Pivotal Software, Inc. All rights reserved. */
+package com.rabbitmq.integration.tests;
+
+import com.rabbitmq.jms.admin.RMQConnectionFactory;
+import com.rabbitmq.jms.admin.RMQDestination;
+import com.rabbitmq.jms.client.SendingContextConsumer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ *
+ */
+public class RpcWithAmqpDirectReplyIT {
+
+    private static final String QUEUE_NAME = "test.queue." + RpcWithAmqpDirectReplyIT.class.getCanonicalName();
+    private static final Logger LOGGER = LoggerFactory.getLogger(RpcWithAmqpDirectReplyIT.class);
+
+    Connection serverConnection, clientConnection;
+
+    RpcServer rpcServer;
+
+    protected static void drainQueue(Session session, Queue queue) throws Exception {
+        MessageConsumer receiver = session.createConsumer(queue);
+        Message msg = receiver.receiveNoWait();
+        while (msg != null) {
+            msg = receiver.receiveNoWait();
+        }
+    }
+
+    static SendingContextConsumer destinationAlreadyDeclaredForRpcResponse() {
+        return ctx -> {
+            if (ctx.getMessage().getJMSCorrelationID() != null && ctx.getDestination() instanceof RMQDestination) {
+                RMQDestination destination = (RMQDestination) ctx.getDestination();
+                destination.setDeclared(true);
+            }
+        };
+    }
+
+    @BeforeEach
+    public void init() throws Exception {
+        ConnectionFactory connectionFactory = AbstractTestConnectionFactory.getTestConnectionFactory()
+            .getConnectionFactory();
+        clientConnection = connectionFactory.createConnection();
+        clientConnection.start();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        rpcServer.close();
+        if (clientConnection != null) {
+            clientConnection.close();
+        }
+        if (serverConnection != null) {
+            serverConnection.close();
+        }
+        com.rabbitmq.client.ConnectionFactory cf = new com.rabbitmq.client.ConnectionFactory();
+        try (com.rabbitmq.client.Connection c = cf.newConnection()) {
+            c.createChannel().queueDelete(QUEUE_NAME);
+        }
+    }
+
+    @Test
+    public void responseOkWhenServerDoesNotRecreateTemporaryResponseQueue() throws Exception {
+        setupRpcServer(destinationAlreadyDeclaredForRpcResponse());
+
+        String messageContent = UUID.randomUUID().toString();
+        Message response = doRpc(messageContent);
+        assertNotNull(response);
+        assertThat(response, is(instanceOf(TextMessage.class)));
+        assertThat(((TextMessage) response).getText(), is("*** " + messageContent + " ***"));
+    }
+
+    Message doRpc(String messageContent) throws Exception {
+        Session session = clientConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        TextMessage message = session.createTextMessage(messageContent);
+        message.setJMSCorrelationID(messageContent);
+
+        RMQDestination replyQueue = new RMQDestination(
+            "amq.rabbitmq.reply-to", "", "amq.rabbitmq.reply-to", "amq.rabbitmq.reply-to"
+        );
+        replyQueue.setDeclared(true);
+        MessageProducer producer = session.createProducer(session.createQueue(QUEUE_NAME));
+
+        MessageConsumer responseConsumer = session.createConsumer(replyQueue);
+        BlockingQueue<Message> queue = new ArrayBlockingQueue<>(1);
+        responseConsumer.setMessageListener(msg -> queue.add(msg));
+
+        message.setJMSReplyTo(replyQueue);
+        producer.send(message);
+        return queue.poll(2, TimeUnit.SECONDS);
+    }
+
+    void setupRpcServer(SendingContextConsumer sendingContextConsumer) throws Exception {
+        RMQConnectionFactory connectionFactory = (RMQConnectionFactory) AbstractTestConnectionFactory.getTestConnectionFactory()
+            .getConnectionFactory();
+        connectionFactory.setSendingContextConsumer(sendingContextConsumer);
+        serverConnection = connectionFactory.createConnection();
+        serverConnection.start();
+        Session session = serverConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        Queue queue = session.createQueue(QUEUE_NAME);
+        drainQueue(session, queue);
+        session.close();
+        rpcServer = new RpcServer(serverConnection);
+    }
+
+    private static class RpcServer {
+
+        Session session;
+
+        public RpcServer(Connection connection) throws JMSException {
+            session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+            Destination destination = session.createQueue(QUEUE_NAME);
+            MessageProducer replyProducer = session.createProducer(null);
+            MessageConsumer consumer = session.createConsumer(destination);
+            consumer.setMessageListener(msg -> {
+                TextMessage message = (TextMessage) msg;
+                try {
+                    String text = message.getText();
+                    Destination replyQueue = message.getJMSReplyTo();
+                    if (replyQueue != null) {
+                        TextMessage replyMessage = session.createTextMessage("*** " + text + " ***");
+                        replyMessage.setJMSCorrelationID(message.getJMSCorrelationID());
+                        replyMessage.setStringProperty("JMSType", "TextMessage");
+                        replyProducer.send(replyQueue, replyMessage);
+                    }
+                } catch (JMSException e) {
+                    LOGGER.warn("Error in RPC server", e);
+                }
+            });
+        }
+
+        void close() {
+            try {
+                session.close();
+            } catch (Exception e) {
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit provides support for RabbitMQ direct reply-to when
performing RPC operations. The client just needs to set up the
JMSReplyTo header with a RMQDestination named "amq.rabbitmq.reply-to".

This provides better performance than using a temporary queue, but it
comes with 2 limitations:
 * the reply-to destination is an JMS "AMQP" destination, so only
ByteMessages and TextMessages are supported.
 * the client needs to create a MessageConsumer and register a
MessageListener to get the response, as direct reply-to doesn't work
with basic.get.

Fixes #48