### PR TITLE
Do not declare reply-to destination for consumed messages

### DIFF
--- a/src/main/java/com/rabbitmq/jms/client/RMQMessage.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQMessage.java
@@ -908,6 +908,7 @@ public abstract class RMQMessage implements Message, Cloneable {
         message.setReadonly(true);                                              // Set readOnly - mandatory for received messages
 
         maybeSetupDirectReplyTo(message, response.getProps().getReplyTo());
+        doNotDeclareReplyToDestination(message);
 
         return message;
     }
@@ -927,6 +928,7 @@ public abstract class RMQMessage implements Message, Cloneable {
             message.setReadonly(true);                                              // Set readOnly - mandatory for received messages
 
             maybeSetupDirectReplyTo(message, response.getProps().getReplyTo());
+            doNotDeclareReplyToDestination(message);
 
             return message;
         } catch (IOException x) {
@@ -952,6 +954,23 @@ public abstract class RMQMessage implements Message, Cloneable {
         if (replyTo != null && replyTo.startsWith(DIRECT_REPLY_TO)) {
             RMQDestination replyToDestination = new RMQDestination(DIRECT_REPLY_TO, "", replyTo, replyTo);
             message.setJMSReplyTo(replyToDestination);
+        }
+    }
+
+    /**
+     * Indicates to not declare a reply-to {@link RMQDestination}.
+     * <p>
+     * This is used for inbound messages, when the reply-to destination
+     * is supposed to be already created. This avoids trying to create
+     * a second time a temporary queue.
+     *
+     * @param message
+     * @throws JMSException
+     * @since 1.11.0
+     */
+    private static void doNotDeclareReplyToDestination(RMQMessage message) throws JMSException {
+        if (message.getJMSReplyTo() != null && message.getJMSReplyTo() instanceof RMQDestination) {
+            ((RMQDestination) message.getJMSReplyTo()).setDeclared(true);
         }
     }
 

--- a/src/test/java/com/rabbitmq/integration/tests/RpcIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/RpcIT.java
@@ -29,7 +29,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  *
@@ -84,15 +83,6 @@ public class RpcIT {
     }
 
     @Test
-    public void noResponseWhenServerTriesToRecreateTemporaryResponseQueue() throws Exception {
-        setupRpcServer();
-
-        String messageContent = UUID.randomUUID().toString();
-        Message response = doRpc(messageContent);
-        assertNull(response);
-    }
-
-    @Test
     public void responseOkWhenServerDoesNotRecreateTemporaryResponseQueue() throws Exception {
         setupRpcServer(destinationAlreadyDeclaredForRpcResponse());
 
@@ -130,11 +120,6 @@ public class RpcIT {
         drainQueue(session, queue);
         session.close();
         rpcServer = new RpcServer(serverConnection);
-    }
-
-    void setupRpcServer() throws Exception {
-        setupRpcServer(ctx -> {
-        });
     }
 
     private static class RpcServer {

--- a/src/test/java/com/rabbitmq/integration/tests/SendingContextConsumerIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/SendingContextConsumerIT.java
@@ -1,0 +1,68 @@
+/* Copyright (c) 2018 Pivotal Software, Inc. All rights reserved. */
+package com.rabbitmq.integration.tests;
+
+import com.rabbitmq.jms.admin.RMQConnectionFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.jms.Connection;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ *
+ */
+public class SendingContextConsumerIT {
+
+    private static final String QUEUE_NAME = "test.queue." + SendingContextConsumerIT.class.getCanonicalName();
+    final AtomicInteger sentCount = new AtomicInteger(0);
+    Connection connection;
+
+    protected static void drainQueue(Session session, Queue queue) throws Exception {
+        MessageConsumer receiver = session.createConsumer(queue);
+        Message msg = receiver.receiveNoWait();
+        while (msg != null) {
+            msg = receiver.receiveNoWait();
+        }
+    }
+
+    @BeforeEach
+    public void init() throws Exception {
+        RMQConnectionFactory connectionFactory = (RMQConnectionFactory) AbstractTestConnectionFactory.getTestConnectionFactory()
+            .getConnectionFactory();
+        connectionFactory.setSendingContextConsumer(ctx -> sentCount.incrementAndGet());
+        connection = connectionFactory.createConnection();
+        connection.start();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        if (connection != null) {
+            connection.close();
+        }
+        com.rabbitmq.client.ConnectionFactory cf = new com.rabbitmq.client.ConnectionFactory();
+        try (com.rabbitmq.client.Connection c = cf.newConnection()) {
+            c.createChannel().queueDelete(QUEUE_NAME);
+        }
+    }
+
+    @Test
+    public void sendingContextConsumerShouldBeCalledWhenSendingMessage() throws Exception {
+        Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        TextMessage message = session.createTextMessage("hello");
+        MessageProducer producer = session.createProducer(session.createQueue(QUEUE_NAME));
+        int initialCount = sentCount.get();
+        producer.send(message);
+        assertEquals(initialCount + 1, sentCount.get());
+        producer.send(message);
+        assertEquals(initialCount + 2, sentCount.get());
+    }
+}


### PR DESCRIPTION
This commit instructs to not declare a reply-to RMQDestination for
consumed messages. This avoids trying to create a second time a
temporary reply-to destination (reply-to destinations are supposed to be
created by a RPC client before sending the request).

This happens to also fix #47.

Fixes #69