### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.rabbitmq.jms</groupId>
@@ -7,7 +7,7 @@
   <name>rabbitmq-jms</name>
   <description>RabbitMQ JMS Client</description>
   <version>1.7.0-SNAPSHOT</version>
-  <url>http://www.rabbitmq.com</url>
+  <url>https://www.rabbitmq.com</url>
 
   <packaging>jar</packaging>
 
@@ -19,7 +19,7 @@
     </license>
     <license>
       <name>MPL 1.1</name>
-      <url>http://www.mozilla.org/MPL/MPL-1.1.txt</url>
+      <url>https://www.mozilla.org/MPL/MPL-1.1.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>
@@ -594,7 +594,7 @@
             </executions>
             <configuration>
               <serverId>spring-repo</serverId>
-              <nexusUrl>http://repo.spring.io/artifactory/</nexusUrl>
+              <nexusUrl>https://repo.spring.io/artifactory/</nexusUrl>
               <skipStaging>true</skipStaging>
             </configuration>
           </plugin>
@@ -648,11 +648,11 @@
       <distributionManagement>
         <snapshotRepository>
           <id>spring-repo</id>
-          <url>http://repo.spring.io/libs-snapshot-local</url>
+          <url>https://repo.spring.io/libs-snapshot-local</url>
         </snapshotRepository>
         <repository>
           <id>spring-repo</id>
-          <url>http://repo.spring.io/libs-release-local</url>
+          <url>https://repo.spring.io/libs-release-local</url>
         </repository>
       </distributionManagement>
     </profile>
@@ -967,7 +967,7 @@
   <repositories>
     <repository>
       <id>ossrh</id>
-      <url>http://oss.sonatype.org/content/repositories/releases</url>
+      <url>https://oss.sonatype.org/content/repositories/releases</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -978,7 +978,7 @@
     <repository>
       <id>jboss.org</id>
       <name>Jboss Maven 2 Repository</name>
-      <url>http://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+      <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
     </repository>
   </repositories>
 </project>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://repo.spring.io/artifactory/ (404) with 1 occurrences migrated to:  
  https://repo.spring.io/artifactory/ ([https](https://repo.spring.io/artifactory/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://repository.jboss.org/nexus/content/groups/public-jboss/ with 1 occurrences migrated to:  
  https://repository.jboss.org/nexus/content/groups/public-jboss/ ([https](https://repository.jboss.org/nexus/content/groups/public-jboss/) result 200).
* http://www.rabbitmq.com with 1 occurrences migrated to:  
  https://www.rabbitmq.com ([https](https://www.rabbitmq.com) result 200).
* http://maven.apache.org/maven-v4_0_0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).
* http://www.mozilla.org/MPL/MPL-1.1.txt with 1 occurrences migrated to:  
  https://www.mozilla.org/MPL/MPL-1.1.txt ([https](https://www.mozilla.org/MPL/MPL-1.1.txt) result 301).
* http://oss.sonatype.org/content/repositories/releases with 1 occurrences migrated to:  
  https://oss.sonatype.org/content/repositories/releases ([https](https://oss.sonatype.org/content/repositories/releases) result 302).
* http://repo.spring.io/libs-release-local with 1 occurrences migrated to:  
  https://repo.spring.io/libs-release-local ([https](https://repo.spring.io/libs-release-local) result 302).
* http://repo.spring.io/libs-snapshot-local with 1 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot-local ([https](https://repo.spring.io/libs-snapshot-local) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8081/nexus/ with 1 occurrences
* http://localhost:8081/repository/maven-releases/ with 1 occurrences
* http://localhost:8081/repository/maven-snapshots/ with 1 occurrences
* http://maven.apache.org/POM/4.0.0 with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences