### PR TITLE
URL Cleanup

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.rabbitmq.jms</groupId>
@@ -7,7 +7,7 @@
   <name>rabbitmq-jms</name>
   <description>RabbitMQ JMS Client</description>
   <version>2.0.0-SNAPSHOT</version>
-  <url>http://www.rabbitmq.com</url>
+  <url>https://www.rabbitmq.com</url>
 
   <packaging>jar</packaging>
 
@@ -19,7 +19,7 @@
     </license>
     <license>
       <name>MPL 1.1</name>
-      <url>http://www.mozilla.org/MPL/MPL-1.1.txt</url>
+      <url>https://www.mozilla.org/MPL/MPL-1.1.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>
@@ -733,7 +733,7 @@
   <repositories>
     <repository>
       <id>ossrh</id>
-      <url>http://oss.sonatype.org/content/repositories/releases</url>
+      <url>https://oss.sonatype.org/content/repositories/releases</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -744,7 +744,7 @@
     <repository>
       <id>jboss.org</id>
       <name>Jboss Maven 2 Repository</name>
-      <url>http://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+      <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
     </repository>
   </repositories>
 </project>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://repository.jboss.org/nexus/content/groups/public-jboss/ with 1 occurrences migrated to:  
  https://repository.jboss.org/nexus/content/groups/public-jboss/ ([https](https://repository.jboss.org/nexus/content/groups/public-jboss/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 with 2 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://www.rabbitmq.com with 1 occurrences migrated to:  
  https://www.rabbitmq.com ([https](https://www.rabbitmq.com) result 200).
* http://maven.apache.org/maven-v4_0_0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).
* http://www.mozilla.org/MPL/MPL-1.1.txt with 1 occurrences migrated to:  
  https://www.mozilla.org/MPL/MPL-1.1.txt ([https](https://www.mozilla.org/MPL/MPL-1.1.txt) result 301).
* http://oss.sonatype.org/content/repositories/releases with 1 occurrences migrated to:  
  https://oss.sonatype.org/content/repositories/releases ([https](https://oss.sonatype.org/content/repositories/releases) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences