### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-[Contributor Covenant](http://contributor-covenant.org), version 1.3.0, available at
-[contributor-covenant.org/version/1/3/0/](http://contributor-covenant.org/version/1/3/0/)
+[Contributor Covenant](https://contributor-covenant.org), version 1.3.0, available at
+[contributor-covenant.org/version/1/3/0/](https://contributor-covenant.org/version/1/3/0/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ The process is fairly standard:
  * Clone [RabbitMQ umbrella repository](https://github.com/rabbitmq/rabbitmq-public-umbrella)
  * `cd umbrella`, `make co`
  * Create a branch with a descriptive name in the relevant repositories
- * Make your changes, run tests, commit with a [descriptive message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html), push to your fork
+ * Make your changes, run tests, commit with a [descriptive message](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html), push to your fork
  * Submit pull requests with an explanation what has been changed and **why**
  * Submit a filled out and signed [Contributor Agreement](https://github.com/rabbitmq/ca#how-to-submit) if needed (see below)
  * Be patient. We will get to your pull request eventually

--- a/LICENSE-MPL-RabbitMQ
+++ b/LICENSE-MPL-RabbitMQ
@@ -437,7 +437,7 @@ EXHIBIT A -Mozilla Public License.
      ``The contents of this file are subject to the Mozilla Public License
      Version 1.1 (the "License"); you may not use this file except in
      compliance with the License. You may obtain a copy of the License at
-     http://www.mozilla.org/MPL/
+     https://www.mozilla.org/MPL/
 
      Software distributed under the License is distributed on an "AS IS"
      basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the

--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -88,7 +88,7 @@ Apache Geronimo
 Copyright 2003-2008 The Apache Software Foundation
 
 This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).
 
 
 --------------- SECTION 3: Mozilla Public License, V1.1 ----------
@@ -101,7 +101,7 @@ Mozilla Public License, V1.1 is applicable to the following component(s).
 //  The contents of this file are subject to the Mozilla Public License
 //  Version 1.1 (the "License"); you may not use this file except in
 //  compliance with the License. You may obtain a copy of the License
-//  at http://www.mozilla.org/MPL/
+//  at https://www.mozilla.org/MPL/
 //
 //  Software distributed under the License is distributed on an "AS IS"
 //  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
@@ -147,7 +147,7 @@ amqp-client-3.6.2-sources.jar\com\rabbitmq\client\impl\VariableLinkedBlockingQue
  */
 * Written by Doug Lea with assistance from members of JCP JSR-166
  * Expert Group and released to the public domain, as explained at
- * http://creativecommons.org/licenses/publicdomain
+ * https://creativecommons.org/licenses/publicdomain
  */
 
 
@@ -798,7 +798,7 @@ EXHIBIT A -Mozilla Public License.
    Version 1.1 (the "License"); you may not use this file except in
    compliance with the License. You may obtain a copy of the License at
 
-   http://www.mozilla.org/MPL/
+   https://www.mozilla.org/MPL/
 
    Software distributed under the License is distributed on an "AS IS"
    basis, WITHOUT WARRANTY OF
@@ -844,7 +844,7 @@ available (as would be noted above), you may obtain a copy of
 the source code corresponding to the binaries for such open
 source components and modifications thereto, if any, (the
 "Source Files"), by downloading the Source Files from Pivotal's website at
-http://www.pivotal.io/open-source, or by sending a request,
+https://www.pivotal.io/open-source, or by sending a request,
 with your name and address to: Pivotal Software, Inc., 3496 Deer Creek Rd,
 Palo Alto, CA 94304, Attention: General Counsel. All such requests should
 clearly specify: OPEN SOURCE FILES REQUEST, Attention General Counsel.

--- a/doc-notes/docupdates1.1.0.md
+++ b/doc-notes/docupdates1.1.0.md
@@ -239,7 +239,7 @@ Here is a complete list of the attributes/properties available:
       The AMQP URI string used to establish a RabbitMQ connection. The value can encode the <code>host</code>, <code>port</code>,
       <code>userid</code>, <code>password</code> and <code>virtualHost</code> in a single string. Both ‘amqp’ and ‘amqps’ schemes are
       accepted.
-      See the <a href="http://www.rabbitmq.com/uri-spec.html">amqp uri spec</a> on the public RabbitMQ site for details. Note: this
+      See the <a href="https://www.rabbitmq.com/uri-spec.html">amqp uri spec</a> on the public RabbitMQ site for details. Note: this
       property sets other properties and the set order is unspecified.
     </td>
   </tr>

--- a/doc-notes/docupdates1.3.2.md
+++ b/doc-notes/docupdates1.3.2.md
@@ -70,7 +70,7 @@ Here is a complete list of the attributes/properties available:
       <code>username</code>, <code>password</code> and <code>virtualHost</code> properties in a single string.
       Both ‘amqp’ and ‘amqps’ schemes are
       accepted, which set the <code>ssl</code> property.
-      See the <a href="http://www.rabbitmq.com/uri-spec.html">amqp uri spec</a> on the public RabbitMQ site for details. <b><i>Note:</i></b> this
+      See the <a href="https://www.rabbitmq.com/uri-spec.html">amqp uri spec</a> on the public RabbitMQ site for details. <b><i>Note:</i></b> this
       property, if present, is applied first. The other attributes, if present, will override the ones set in <code>uri</code>.
       There is no default value, if not present it is not set.
     </td>

--- a/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
@@ -462,7 +462,7 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
      * Enables TLS on opened connections using the provided TLS protocol
      * version.
      * @param protocol TLS or SSL protocol version.
-     * @see <a href="http://docs.oracle.com/javase/7/docs/technotes/guides/security/SunProviders.html#SunJSSEProvider">JDK documentation on protocol names</a>
+     * @see <a href="https://docs.oracle.com/javase/7/docs/technotes/guides/security/SunProviders.html#SunJSSEProvider">JDK documentation on protocol names</a>
      */
     public void useSslProtocol(String protocol)
     {

--- a/src/main/java/com/rabbitmq/jms/admin/RMQObjectFactory.java
+++ b/src/main/java/com/rabbitmq/jms/admin/RMQObjectFactory.java
@@ -19,7 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * JNDI Factory to create resources in containers such as <a href="http://tomcat.apache.org">Tomcat</a>.
+ * JNDI Factory to create resources in containers such as <a href="https://tomcat.apache.org">Tomcat</a>.
  * <p>
  * An example Tomcat configuration for a {@link ConnectionFactory} would look like:
  * </p>
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
  *           virtualHost=&quot;/&quot;
  *           host=&quot;localhost&quot;/&gt;
  * </pre>
- * <p>Alternatively, a <a href="http://www.rabbitmq.com/uri-spec.html">AMQP uri</a> can be used:
+ * <p>Alternatively, a <a href="https://www.rabbitmq.com/uri-spec.html">AMQP uri</a> can be used:
  * </p>
  * <pre>
  * &lt;Resource name=&quot;jms/ConnectionFactory&quot; type=&quot;javax.jms.ConnectionFactory&quot;

--- a/src/main/java/com/rabbitmq/jms/client/RMQMessage.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQMessage.java
@@ -760,7 +760,7 @@ public abstract class RMQMessage implements Message, Cloneable {
      * </p>
      * {@inheritDoc}
      * <p>
-     * [1] <a href="http://download.oracle.com/otn-pub/jcp/7195-jms-1.1-fr-spec-oth-JSpec/jms-1_1-fr-spec.pdf">JMS 1.1 spec</a> Section 11.3.2.2.
+     * [1] <a href="https://download.oracle.com/otn-pub/jcp/7195-jms-1.1-fr-spec-oth-JSpec/jms-1_1-fr-spec.pdf">JMS 1.1 spec</a> Section 11.3.2.2.
      * </p>
      * @see RMQSession#acknowledgeMessage(RMQMessage)
      */

--- a/src/main/java/com/rabbitmq/jms/util/UriCodec.java
+++ b/src/main/java/com/rabbitmq/jms/util/UriCodec.java
@@ -39,14 +39,14 @@ import java.util.Arrays;
  * <b>URI Specification</b>
  * </p>
  * <p>
- * <a href="http://tools.ietf.org/pdf/rfc2396.pdf">RFC 2396 - Uniform Resource Identifiers (URI): Generic Syntax</a>
- * is obsoleted by <a href="http://tools.ietf.org/pdf/rfc3986.pdf">RFC 3986 -
+ * <a href="https://tools.ietf.org/pdf/rfc2396.pdf">RFC 2396 - Uniform Resource Identifiers (URI): Generic Syntax</a>
+ * is obsoleted by <a href="https://tools.ietf.org/pdf/rfc3986.pdf">RFC 3986 -
  * Uniform Resource Identifier (URI): Generic Syntax</a> which describes in (A)BNF the
  * valid form of an <i>encoded</i> URI.
  * </p>
  * <p>
- * Here is the appendix from <a href="http://tools.ietf.org/pdf/rfc3986.pdf">RFC 3986</a> which gives the ABNF.
- * ABNF itself is defined in <a href="http://tools.ietf.org/pdf/rfc2234.pdf">RFC
+ * Here is the appendix from <a href="https://tools.ietf.org/pdf/rfc3986.pdf">RFC 3986</a> which gives the ABNF.
+ * ABNF itself is defined in <a href="https://tools.ietf.org/pdf/rfc2234.pdf">RFC
  * 2234 - Augmented BNF for Syntax Specifications: ABNF</a> where furthermore the following
  * non-terminals are defined: <code>ALPHA</code> (letters), <code>DIGIT</code> (decimal digits), and
  * <code>HEXDIG</code> (hexadecimal digits).

--- a/src/test/java/com/rabbitmq/jms/client/message/TestMessages.java
+++ b/src/test/java/com/rabbitmq/jms/client/message/TestMessages.java
@@ -193,7 +193,7 @@ public class TestMessages {
         assertEquals(Float.MAX_VALUE, message.getFloat("float"), 1e-20D);
 
         // we must cast to get the same precision error -
-        // http://en.wikipedia.org/wiki/Floating_point
+        // https://en.wikipedia.org/wiki/Floating_point
         assertEquals((double) Float.MAX_VALUE, message.getDouble("float"), 1e-20D);
         assertEquals(Float.MAX_VALUE, message.getFloat("string.float"), 1e-20D);
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://docs.oracle.com/javase/7/docs/technotes/guides/security/SunProviders.html with 1 occurrences migrated to:  
  https://docs.oracle.com/javase/7/docs/technotes/guides/security/SunProviders.html ([https](https://docs.oracle.com/javase/7/docs/technotes/guides/security/SunProviders.html) result 200).
* http://en.wikipedia.org/wiki/Floating_point with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/Floating_point ([https](https://en.wikipedia.org/wiki/Floating_point) result 200).
* http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* http://tomcat.apache.org with 1 occurrences migrated to:  
  https://tomcat.apache.org ([https](https://tomcat.apache.org) result 200).
* http://tools.ietf.org/pdf/rfc2234.pdf with 1 occurrences migrated to:  
  https://tools.ietf.org/pdf/rfc2234.pdf ([https](https://tools.ietf.org/pdf/rfc2234.pdf) result 200).
* http://tools.ietf.org/pdf/rfc2396.pdf with 1 occurrences migrated to:  
  https://tools.ietf.org/pdf/rfc2396.pdf ([https](https://tools.ietf.org/pdf/rfc2396.pdf) result 200).
* http://tools.ietf.org/pdf/rfc3986.pdf with 2 occurrences migrated to:  
  https://tools.ietf.org/pdf/rfc3986.pdf ([https](https://tools.ietf.org/pdf/rfc3986.pdf) result 200).
* http://www.apache.org/ with 1 occurrences migrated to:  
  https://www.apache.org/ ([https](https://www.apache.org/) result 200).
* http://www.rabbitmq.com/uri-spec.html with 3 occurrences migrated to:  
  https://www.rabbitmq.com/uri-spec.html ([https](https://www.rabbitmq.com/uri-spec.html) result 200).
* http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* http://www.mozilla.org/MPL/ with 3 occurrences migrated to:  
  https://www.mozilla.org/MPL/ ([https](https://www.mozilla.org/MPL/) result 301).
* http://www.pivotal.io/open-source with 1 occurrences migrated to:  
  https://www.pivotal.io/open-source ([https](https://www.pivotal.io/open-source) result 301).
* http://creativecommons.org/licenses/publicdomain with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/publicdomain ([https](https://creativecommons.org/licenses/publicdomain) result 302).
* http://download.oracle.com/otn-pub/jcp/7195-jms-1.1-fr-spec-oth-JSpec/jms-1_1-fr-spec.pdf with 1 occurrences migrated to:  
  https://download.oracle.com/otn-pub/jcp/7195-jms-1.1-fr-spec-oth-JSpec/jms-1_1-fr-spec.pdf ([https](https://download.oracle.com/otn-pub/jcp/7195-jms-1.1-fr-spec-oth-JSpec/jms-1_1-fr-spec.pdf) result 302).