### PR TITLE
Add support for publisher confirms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <junit.jupiter.version>5.5.1</junit.jupiter.version>
     <mockito-core.version>3.0.0</mockito-core.version>
     <awaitility.version>3.1.6</awaitility.version>
+    <assertj.version>3.13.2</assertj.version>
     <spring.version>5.1.8.RELEASE</spring.version>
 
     <maven.dependency.plugin.version>2.8</maven.dependency.plugin.version>
@@ -152,6 +153,12 @@
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <version>${awaitility.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>${assertj.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/rabbitmq/jms/client/ConfirmListener.java
+++ b/src/main/java/com/rabbitmq/jms/client/ConfirmListener.java
@@ -1,0 +1,33 @@
+/* Copyright (c) 2019 Pivotal Software, Inc. All rights reserved. */
+package com.rabbitmq.jms.client;
+
+/**
+ * Listener to be notified of publisher confirms.
+ * <p>
+ * Publisher Confirms are a RabbitMQ extension to the AMQP protocol.
+ * In the context of the JMS client, they allow to be asynchronously
+ * notified when an outbound message has been confirmed by the broker
+ * (meaning the message made it safely to the broker).
+ * <p>
+ * Note publisher confirms are enabled at the {@link com.rabbitmq.jms.admin.RMQConnectionFactory} level,
+ * by setting a {@link ConfirmListener} instance with
+ * {@link com.rabbitmq.jms.admin.RMQConnectionFactory#setConfirmListener(ConfirmListener)}. This
+ * means all the AMQP {@link com.rabbitmq.client.Channel} created from the {@link com.rabbitmq.jms.admin.RMQConnectionFactory}
+ * instance will have publisher confirms enabled.
+ *
+ * @see <a href="https://www.rabbitmq.com/confirms.html#publisher-confirms">Publisher Confirms</a>
+ * @see <a href="https://www.rabbitmq.com/publishers.html#data-safety">Publisher Guide</a>
+ * @see com.rabbitmq.jms.admin.RMQConnectionFactory#setConfirmListener(ConfirmListener)
+ * @since 1.13.0
+ */
+@FunctionalInterface
+public interface ConfirmListener {
+
+    /**
+     * Callback invoked when an outbound message is confirmed.
+     *
+     * @param context information about the confirmed message
+     */
+    void handle(PublisherConfirmContext context);
+
+}

--- a/src/main/java/com/rabbitmq/jms/client/ConnectionParams.java
+++ b/src/main/java/com/rabbitmq/jms/client/ConnectionParams.java
@@ -78,6 +78,13 @@ public class ConnectionParams {
      */
     private ReceivingContextConsumer receivingContextConsumer;
 
+    /**
+     * Callback for publisher confirms.
+     *
+     * @since 1.13.0
+     */
+    private ConfirmListener confirmListener;
+
     public Connection getRabbitConnection() {
         return rabbitConnection;
     }
@@ -175,5 +182,14 @@ public class ConnectionParams {
     public ConnectionParams setReceivingContextConsumer(ReceivingContextConsumer receivingContextConsumer) {
         this.receivingContextConsumer = receivingContextConsumer;
         return this;
+    }
+
+    public ConnectionParams setConfirmListener(ConfirmListener confirmListener) {
+        this.confirmListener = confirmListener;
+        return this;
+    }
+
+    public ConfirmListener getConfirmListener() {
+        return confirmListener;
     }
 }

--- a/src/main/java/com/rabbitmq/jms/client/PublisherConfirmContext.java
+++ b/src/main/java/com/rabbitmq/jms/client/PublisherConfirmContext.java
@@ -1,0 +1,39 @@
+/* Copyright (c) 2019 Pivotal Software, Inc. All rights reserved. */
+package com.rabbitmq.jms.client;
+
+import javax.jms.Message;
+
+/**
+ * Information an outbound message being confirmed.
+ *
+ * @see ConfirmListener
+ * @since 1.13.0
+ */
+public class PublisherConfirmContext {
+
+    private final Message message;
+    private final boolean ack;
+
+    PublisherConfirmContext(Message message, boolean ack) {
+        this.message = message;
+        this.ack = ack;
+    }
+
+    /**
+     * The message being confirmed.
+     *
+     * @return the confirmed message
+     */
+    public Message getMessage() {
+        return message;
+    }
+
+    /**
+     * Whether the message is confirmed or nack-ed (considered lost).
+     *
+     * @return true if confirmed, false if nack-ed
+     */
+    public boolean isAck() {
+        return ack;
+    }
+}

--- a/src/main/java/com/rabbitmq/jms/client/PublisherConfirmsUtils.java
+++ b/src/main/java/com/rabbitmq/jms/client/PublisherConfirmsUtils.java
@@ -1,0 +1,90 @@
+/* Copyright (c) 2019 Pivotal Software, Inc. All rights reserved. */
+package com.rabbitmq.jms.client;
+
+import com.rabbitmq.client.Channel;
+
+import javax.jms.Message;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+/**
+ * Utility class to handle publisher confirms.
+ *
+ * @since 1.13.0
+ */
+class PublisherConfirmsUtils {
+
+    /**
+     * Enables publisher confirms support.
+     * <p>
+     * Adds a {@link com.rabbitmq.client.ConfirmListener} to the AMQP {@link Channel}
+     * and notifies the user-provided {@link ConfirmListener} when confirms notified
+     * arrive.
+     * <p>
+     * Returns a {@link PublishingListener} that must be called whenever a message is published.
+     *
+     * @param channel
+     * @param confirmListener
+     * @return
+     */
+    static PublishingListener configurePublisherConfirmsSupport(Channel channel, ConfirmListener confirmListener) {
+        final Map<Long, Message> outstandingConfirms = new ConcurrentHashMap<>();
+        final AtomicLong multipleLowerBound = new AtomicLong(1);
+        PublishingListener publishingListener = (message, sequenceNumber) -> {
+            outstandingConfirms.put(sequenceNumber, message);
+        };
+        channel.addConfirmListener(new com.rabbitmq.client.ConfirmListener() {
+            @Override
+            public void handleAck(long deliveryTag, boolean multiple) {
+                cleanPublisherConfirmsCorrelation(
+                        outstandingConfirms, multipleLowerBound,
+                        deliveryTag, multiple, message -> confirmListener.handle(new PublisherConfirmContext(message, true))
+                );
+            }
+
+            @Override
+            public void handleNack(long deliveryTag, boolean multiple) {
+                cleanPublisherConfirmsCorrelation(
+                        outstandingConfirms, multipleLowerBound,
+                        deliveryTag, multiple, message -> confirmListener.handle(new PublisherConfirmContext(message, false))
+                );
+            }
+        });
+        return publishingListener;
+    }
+
+    /**
+     * Cleans the data structure used to correlate publishing sequence numbers to messages when a confirm comes in.
+     * <p>
+     * Invoke a provided callback for each message confirmed/nack-ed.
+     *
+     * @param outstandingConfirms
+     * @param multipleLowerBound
+     * @param deliveryTag
+     * @param multiple
+     * @param messageConsumer
+     */
+    private static void cleanPublisherConfirmsCorrelation(Map<Long, Message> outstandingConfirms, AtomicLong multipleLowerBound,
+                                                          long deliveryTag, boolean multiple, Consumer<Message> messageConsumer) {
+        Long lowerBound = multipleLowerBound.get();
+        if (multiple) {
+            for (long i = lowerBound; i <= deliveryTag; i++) {
+                Message message = outstandingConfirms.remove(i);
+                if (message != null) {
+                    messageConsumer.accept(message);
+                }
+            }
+        } else {
+            Message message = outstandingConfirms.remove(deliveryTag);
+            if (message != null) {
+                messageConsumer.accept(message);
+            }
+            if (deliveryTag == lowerBound + 1) {
+                multipleLowerBound.compareAndSet(lowerBound, deliveryTag);
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/rabbitmq/jms/client/PublishingListener.java
+++ b/src/main/java/com/rabbitmq/jms/client/PublishingListener.java
@@ -1,0 +1,15 @@
+/* Copyright (c) 2019 Pivotal Software, Inc. All rights reserved. */
+package com.rabbitmq.jms.client;
+
+import javax.jms.Message;
+
+/**
+ * Internal interface to notify about a published message when publisher confirms are enabled.
+ *
+ * @since 1.13.0
+ */
+interface PublishingListener {
+
+    void publish(Message message, long sequenceNumber);
+
+}

--- a/src/main/java/com/rabbitmq/jms/client/RMQConnection.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQConnection.java
@@ -119,6 +119,13 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
     private final ReceivingContextConsumer receivingContextConsumer;
 
     /**
+     * Callback for publisher confirms.
+     *
+     * @since 1.13.0
+     */
+    private final ConfirmListener confirmListener;
+
+    /**
      * Classes in these packages can be transferred via ObjectMessage.
      *
      * @see WhiteListObjectInputStream
@@ -144,6 +151,7 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
         this.amqpPropertiesCustomiser = connectionParams.getAmqpPropertiesCustomiser();
         this.sendingContextConsumer = connectionParams.getSendingContextConsumer();
         this.receivingContextConsumer = connectionParams.getReceivingContextConsumer();
+        this.confirmListener = connectionParams.getConfirmListener();
     }
 
     /**
@@ -195,6 +203,7 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
             .setAmqpPropertiesCustomiser(this.amqpPropertiesCustomiser)
             .setSendingContextConsumer(this.sendingContextConsumer)
             .setReceivingContextConsumer(this.receivingContextConsumer)
+            .setConfirmListener(this.confirmListener)
         );
         session.setTrustedPackages(this.trustedPackages);
         this.sessions.add(session);
@@ -381,6 +390,9 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
         }
         if (transactional) {
             channel.txSelect();
+        }
+        if (this.confirmListener != null) {
+            channel.confirmSelect();
         }
         return channel;
     }

--- a/src/main/java/com/rabbitmq/jms/client/SessionParams.java
+++ b/src/main/java/com/rabbitmq/jms/client/SessionParams.java
@@ -74,6 +74,13 @@ public class SessionParams {
      */
     private ReceivingContextConsumer receivingContextConsumer;
 
+    /**
+     * Callback for publisher confirms.
+     *
+     * @since 1.13.0
+     */
+    private ConfirmListener confirmListener;
+
     public RMQConnection getConnection() {
         return connection;
     }
@@ -171,5 +178,14 @@ public class SessionParams {
 
     public ReceivingContextConsumer getReceivingContextConsumer() {
         return receivingContextConsumer;
+    }
+
+    public SessionParams setConfirmListener(ConfirmListener confirmListener) {
+        this.confirmListener = confirmListener;
+        return this;
+    }
+
+    public ConfirmListener getConfirmListener() {
+        return confirmListener;
     }
 }

--- a/src/test/java/com/rabbitmq/integration/tests/PublisherConfirmsIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/PublisherConfirmsIT.java
@@ -1,0 +1,77 @@
+/* Copyright (c) 2019 Pivotal Software, Inc. All rights reserved. */
+package com.rabbitmq.integration.tests;
+
+import com.rabbitmq.jms.admin.RMQConnectionFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.jms.*;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.waitAtMost;
+
+/**
+ * Integration test for publisher confirms.
+ */
+public class PublisherConfirmsIT {
+
+    private static final String QUEUE_NAME = "test.queue." + PublisherConfirmsIT.class.getCanonicalName();
+
+    Connection connection;
+    Map<String, Message> ackedMessages = new ConcurrentHashMap<>();
+
+    @BeforeEach
+    public void init() throws Exception {
+        ackedMessages.clear();
+        RMQConnectionFactory connectionFactory = (RMQConnectionFactory) AbstractTestConnectionFactory.getTestConnectionFactory()
+                .getConnectionFactory();
+        connectionFactory.setConfirmListener(context -> {
+            TextMessage textMessage = (TextMessage) context.getMessage();
+            try {
+                ackedMessages.put(textMessage.getText(), textMessage);
+            } catch (JMSException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        connection = connectionFactory.createConnection();
+        connection.start();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        if (connection != null) {
+            connection.close();
+        }
+        com.rabbitmq.client.ConnectionFactory cf = new com.rabbitmq.client.ConnectionFactory();
+        try (com.rabbitmq.client.Connection c = cf.newConnection()) {
+            c.createChannel().queueDelete(QUEUE_NAME);
+        }
+    }
+
+    @Test
+    public void confirmListenerShouldBeCalledWhenConfirmListenerIsEnabled() throws Exception {
+        Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+        Queue queue = session.createQueue(QUEUE_NAME);
+        MessageConsumer consumer = session.createConsumer(queue);
+        CountDownLatch receivedMessagesLatch = new CountDownLatch(2);
+        consumer.setMessageListener(msg -> receivedMessagesLatch.countDown());
+
+        TextMessage message = session.createTextMessage("hello1");
+        MessageProducer producer = session.createProducer(queue);
+        producer.send(message);
+        waitAtMost(5, TimeUnit.SECONDS).until(() -> ackedMessages.size() == 1);
+        assertThat(ackedMessages).containsKeys("hello1").containsValues(message);
+        message = session.createTextMessage("hello2");
+        producer.send(message);
+        waitAtMost(5, TimeUnit.SECONDS).until(() -> ackedMessages.size() == 2);
+        assertThat(ackedMessages).containsKeys("hello2").containsValues(message);
+
+        assertThat(receivedMessagesLatch.await(5, TimeUnit.SECONDS)).isTrue();
+    }
+
+}

--- a/src/test/java/com/rabbitmq/jms/client/PublisherConfirmsUtilsTest.java
+++ b/src/test/java/com/rabbitmq/jms/client/PublisherConfirmsUtilsTest.java
@@ -1,0 +1,125 @@
+/* Copyright (c) 2019 Pivotal Software, Inc. All rights reserved. */
+package com.rabbitmq.jms.client;
+
+import com.rabbitmq.client.Channel;
+import org.junit.jupiter.api.Test;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.TextMessage;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class PublisherConfirmsUtilsTest {
+
+    static TextMessage message(String body) throws Exception {
+        TextMessage message = mock(TextMessage.class);
+        when(message.getText()).thenReturn(body);
+        return message;
+    }
+
+    static int toInt(Message message) {
+        try {
+            return Integer.valueOf(((TextMessage) message).getText());
+        } catch (JMSException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void configurePublisherConfirmsSupport() throws Exception {
+        Channel channel = mock(Channel.class);
+        AtomicReference<com.rabbitmq.client.ConfirmListener> amqpConfirmListener = new AtomicReference<>();
+        doAnswer(invocation -> {
+            amqpConfirmListener.set(invocation.getArgument(0, com.rabbitmq.client.ConfirmListener.class));
+            return null;
+        }).when(channel).addConfirmListener(any(com.rabbitmq.client.ConfirmListener.class));
+
+        int messageCount = 50;
+
+        List<Integer> acked = Collections.synchronizedList(new ArrayList<>());
+        List<Integer> nacked = Collections.synchronizedList(new ArrayList<>());
+        CountDownLatch latch = new CountDownLatch(messageCount);
+        ConfirmListener confirmListener = context -> {
+            if (context.isAck()) {
+                acked.add(toInt(context.getMessage()));
+            } else {
+                nacked.add(toInt(context.getMessage()));
+            }
+            latch.countDown();
+        };
+
+        BlockingQueue<TextMessage> messagesSentToServer = new LinkedBlockingQueue<>();
+        new Thread(() -> {
+            AtomicLong serverPublishingSequence = new AtomicLong(1);
+            while (true) {
+                try {
+                    TextMessage message = messagesSentToServer.poll(10, TimeUnit.SECONDS);
+                    int body = Integer.valueOf(message.getText());
+                    long sequenceNumber = serverPublishingSequence.getAndIncrement();
+                    if (body <= 10) {
+                        // ack 1-10 individually
+                        amqpConfirmListener.get().handleAck(sequenceNumber, false);
+                    } else if (body == 20) {
+                        // ack 11-20 in batch
+                        amqpConfirmListener.get().handleAck(sequenceNumber, true);
+                    } else if (body == 25) {
+                        // nack 25 individually
+                        amqpConfirmListener.get().handleNack(sequenceNumber, false);
+                    } else if (body == 30) {
+                        // ack 21-30 in batch (- 25, which has been nack-ed)
+                        amqpConfirmListener.get().handleAck(sequenceNumber, true);
+                    } else if (body == 35) {
+                        // ack 35 individually
+                        amqpConfirmListener.get().handleAck(sequenceNumber, false);
+                    } else if (body == 40) {
+                        // nack 31-40 in batch (- 35, which has been ack-ed)
+                        amqpConfirmListener.get().handleNack(sequenceNumber, true);
+                    } else if (body >= 41) {
+                        // nack 41-50 individually
+                        amqpConfirmListener.get().handleNack(sequenceNumber, false);
+                    }
+                    if (body == messageCount) {
+                        return;
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }).start();
+
+        PublishingListener publishingListener = PublisherConfirmsUtils.configurePublisherConfirmsSupport(
+                channel, confirmListener
+        );
+        AtomicLong clientPublishingSequence = new AtomicLong(1);
+
+        for (int i = 1; i <= messageCount; i++) {
+            TextMessage message = message(String.valueOf(i));
+            publishingListener.publish(message, clientPublishingSequence.getAndIncrement());
+            messagesSentToServer.offer(message);
+        }
+
+        assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(acked.size() + nacked.size()).isEqualTo(messageCount);
+        assertThat(acked).hasSize(30)
+                .containsAll(IntStream.range(1, 30).filter(i -> i != 25).boxed().collect(Collectors.toList()))
+                .contains(30, 35);
+        assertThat(nacked).hasSize(20)
+                .contains(25)
+                .containsAll(IntStream.range(31, 50).filter(i -> i != 35).boxed().collect(Collectors.toList()));
+    }
+
+}

--- a/src/test/java/com/rabbitmq/jms/client/RMQMessageProducerTest.java
+++ b/src/test/java/com/rabbitmq/jms/client/RMQMessageProducerTest.java
@@ -105,7 +105,7 @@ public class RMQMessageProducerTest {
         }
 
         @Override
-        protected void sendJMSMessage(RMQDestination destination, RMQMessage msg, int deliveryMode, int priority, long timeToLive) throws JMSException {
+        protected void sendJMSMessage(RMQDestination destination, RMQMessage msg, Message originalMessage, int deliveryMode, int priority, long timeToLive) throws JMSException {
             this.message = msg;
         }
     }


### PR DESCRIPTION
Add an optional callback to the RMQConnectionFactory to be notified
of confirmed/nack-ed published messages. Setting this callback will
enable publisher confirms globally (for all the children objects created
by the RMQConnectionFactory instance).

Publisher confirms use a publishing sequence number to correlate
messages. As there is no such concept in JMS, the JMS client takes care
of mapping sequence numbers with original messages.

The confirm callback has one method with one context parameter. This
allows adding more information about published messages later (e.g. the
session or producer instance), without breaking changes. The context
consists now of the original message and a flag for confirmed or nacked.

Fixes #115