### PR TITLE
Externalized options used when declaring queue in RMQSession.declareRMQQueue

### DIFF
--- a/src/main/java/com/rabbitmq/jms/client/RMQSession.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQSession.java
@@ -199,6 +199,9 @@ public class RMQSession implements Session, QueueSession, TopicSession {
      */
     private List<String> trustedPackages = WhiteListObjectInputStream.DEFAULT_TRUSTED_PACKAGES;
 
+    /** Options to be used when declaring a queue while creating a producer **/
+    private Map<String,Object> declaredQueueOptions = null;
+
     /**
      * Creates a session object associated with a connection
      * @param sessionParams parameters for this session
@@ -849,8 +852,6 @@ public class RMQSession implements Session, QueueSession, TopicSession {
          */
         boolean exclusive = dest.isTemporary() || ((!dest.isQueue()) && (!durableSubscriber));
 
-        Map<String,Object> options = null; //new HashMap<String,Object>();
-
         if (dest.isQueue()) {
             if (dest.noNeedToDeclareExchange()) {
                 logger.warn("no need to declare built-in exchange for queue destination '{}'", dest);
@@ -876,17 +877,17 @@ public class RMQSession implements Session, QueueSession, TopicSession {
 
         try { /* Declare the queue to RabbitMQ -- this creates it if it doesn't already exist */
             this.logger.debug("declare RabbitMQ queue name({}), durable({}), exclusive({}), auto-delete({}), properties({})",
-                              queueName, durable, exclusive, false, options);
+                              queueName, durable, exclusive, false, declaredQueueOptions);
             this.channel.queueDeclare(queueName,
                                       durable,
                                       exclusive,
                                       autoDelete,
-                                      options); // object properties
+                                      declaredQueueOptions); // object properties
 
             /* Temporary or 'topic queues' are exclusive and therefore get deleted by RabbitMQ on close */
         } catch (Exception x) {
             this.logger.error("RabbitMQ exception on queue declare name({}), durable({}), exclusive({}), auto-delete({}), properties({})",
-                              queueName, durable, exclusive, autoDelete, options, x);
+                              queueName, durable, exclusive, autoDelete, declaredQueueOptions, x);
             throw new RMQJMSException(x);
         }
 
@@ -899,7 +900,7 @@ public class RMQSession implements Session, QueueSession, TopicSession {
                         null); // arguments
             } catch (Exception x) {
                 this.logger.error("RabbitMQ exception on queue declare name({}), durable({}), exclusive({}), auto-delete({}), properties({})",
-                        queueName, durable, exclusive, false, options, x);
+                        queueName, durable, exclusive, false, declaredQueueOptions, x);
                 throw new RMQJMSException(x);
             }
         }

--- a/src/main/java/com/rabbitmq/jms/client/RMQSession.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQSession.java
@@ -382,6 +382,8 @@ public class RMQSession implements Session, QueueSession, TopicSession {
         this.trustedPackages = trustedPackages;
     }
 
+    public void setDeclaredQueueOptions(Map<String, Object> declaredQueueOptions) { this.declaredQueueOptions = declaredQueueOptions; }
+
     /**
      * Same as {@link RMQSession#getAcknowledgeMode()} but without
      * a declared exception in the throws clause.


### PR DESCRIPTION
This gives the user the option to set the options that will be used when declaring a queue in the declareRMQQueue method.

With Rabbit 3.8.0-rc.1 I noticed that when creating classic queues via the management console an argument of "x-queue-type" set to "classic" is created, I assume this is to differentiate between classic and quorum queues. However this prevents channel.queueDeclare calls from working correctly unless an option is provided. This change would also let people use lazy queues and queues with other types of arguments set.

This change would help my team out quite a bit with what we are trying to do, if I can revise this pull request to better fit your standards please let me know. Thanks!