### PR TITLE
Add channelsQos property to JNDI Factory

### DIFF
--- a/src/main/java/com/rabbitmq/jms/admin/RMQObjectFactory.java
+++ b/src/main/java/com/rabbitmq/jms/admin/RMQObjectFactory.java
@@ -93,6 +93,7 @@ import org.slf4j.LoggerFactory;
  * <li>port</li>
  * <li>queueBrowserReadMax</li>
  * <li>onMessageTimeoutMs</li>
+ * <li>channelsQos</li>
  * <li>ssl</li>
  * <li>terminationTimeout</li>
  * <li>username</li>
@@ -191,6 +192,7 @@ public class RMQObjectFactory implements ObjectFactory {
         f.setPort               (getIntProperty    (ref, environment, "port",                true, f.getPort()               ));
         f.setQueueBrowserReadMax(getIntProperty    (ref, environment, "queueBrowserReadMax", true, f.getQueueBrowserReadMax()));
         f.setOnMessageTimeoutMs (getIntProperty    (ref, environment, "onMessageTimeoutMs",  true, f.getOnMessageTimeoutMs() ));
+        f.setChannelsQos        (getIntProperty    (ref, environment, "channelsQos",         true, f.getChannelsQos()        ));
         if (getBooleanProperty(ref, environment, "ssl",                 true, f.isSsl())) {
             try {
                 f.useSslProtocol();

--- a/src/test/java/com/rabbitmq/jms/admin/RMQObjectFactoryTest.java
+++ b/src/test/java/com/rabbitmq/jms/admin/RMQObjectFactoryTest.java
@@ -8,6 +8,7 @@ import javax.naming.NamingException;
 import javax.naming.Reference;
 import java.util.Hashtable;
 
+import static com.rabbitmq.jms.client.RMQConnection.NO_CHANNEL_QOS;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -35,6 +36,7 @@ public class RMQObjectFactoryTest {
         assertEquals("guest", createdConFactory.getPassword());
         assertEquals("/", createdConFactory.getVirtualHost());
         assertEquals("localhost", createdConFactory.getHost());
+        assertEquals(NO_CHANNEL_QOS, createdConFactory.getChannelsQos());
 
     }
 
@@ -48,6 +50,7 @@ public class RMQObjectFactoryTest {
             put("password", "1234");
             put("virtualHost", "/fake");
             put("host", "fakeHost");
+            put("channelsQos", 10);
         }};
 
         Object createdObject = rmqObjectFactory.getObjectInstance("anything but a javax.naming.Reference", new CompositeName("java:global/jms/TestConnectionFactory"), null, environment);
@@ -61,6 +64,7 @@ public class RMQObjectFactoryTest {
         assertEquals("1234", createdConFactory.getPassword());
         assertEquals("/fake", createdConFactory.getVirtualHost());
         assertEquals("fakeHost", createdConFactory.getHost());
+        assertEquals(10, createdConFactory.getChannelsQos());
 
     }
 


### PR DESCRIPTION
Since channelsQos property is already managed in RMQConnectionFactory, I would like to add some support for applications that use JNDI to connect to a RabbitMQ broker and need to define a prefetch count for performance reasons.