### PR TITLE
Return 0 JMS timestamp if property is null

### DIFF
--- a/src/main/java/com/rabbitmq/jms/client/RMQMessage.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQMessage.java
@@ -242,7 +242,12 @@ public abstract class RMQMessage implements Message, Cloneable {
      */
     @Override
     public long getJMSTimestamp() throws JMSException {
-        return this.getLongProperty(JMS_MESSAGE_TIMESTAMP);
+        Object timestamp = this.getObjectProperty(JMS_MESSAGE_TIMESTAMP);
+        if (timestamp == null) {
+            return 0L;
+        } else {
+            return convertToLong(timestamp);
+        }
     }
 
     /**
@@ -496,7 +501,10 @@ public abstract class RMQMessage implements Message, Cloneable {
      */
     @Override
     public long getLongProperty(String name) throws JMSException {
-        Object o = this.getObjectProperty(name);
+        return convertToLong(this.getObjectProperty(name));
+    }
+
+    private static long convertToLong(Object o) throws JMSException {
         if (o == null)
             throw new NumberFormatException("Null is not a valid long");
         else if (o instanceof String) {

--- a/src/test/java/com/rabbitmq/integration/tests/SimpleAmqpQueueMessageIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/SimpleAmqpQueueMessageIT.java
@@ -1,6 +1,7 @@
 /* Copyright (c) 2013-2020 VMware, Inc. or its affiliates. All rights reserved. */
 package com.rabbitmq.integration.tests;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -22,6 +23,7 @@ import javax.jms.QueueSession;
 import javax.jms.Session;
 import javax.jms.TextMessage;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.rabbitmq.client.AMQP;
@@ -187,6 +189,7 @@ public class SimpleAmqpQueueMessageIT extends AbstractAmqpITQueue {
 
         assertEquals(STRING_PROP_VALUE, message.getStringProperty(USER_STRING_PROPERTY_NAME), "String property not transferred");
         assertEquals("42", message.getStringProperty("DummyProp"), "Numeric property not transferred");
+        assertThat(message.getJMSTimestamp()).isZero();
     }
 
     @Test
@@ -238,6 +241,7 @@ public class SimpleAmqpQueueMessageIT extends AbstractAmqpITQueue {
 
         assertEquals(STRING_PROP_VALUE, message.getStringProperty(USER_STRING_PROPERTY_NAME), "String property not transferred");
         assertEquals("42", message.getStringProperty("DummyProp"), "Numeric property not transferred");
+        assertThat(message.getJMSTimestamp()).isZero();
     }
 
     @Test
@@ -274,6 +278,7 @@ public class SimpleAmqpQueueMessageIT extends AbstractAmqpITQueue {
         assertNotNull(message, "No message received");
         assertEquals(MESSAGE, message.getText(), "Payload doesn't match");
         assertEquals(STRING_PROP_VALUE, message.getStringProperty(USER_STRING_PROPERTY_NAME), "String property not transferred");
+        assertThat(message.getJMSTimestamp()).isGreaterThan(0);
     }
 
 }


### PR DESCRIPTION
The property is not supposed to be null in JMS, but it can in AMQP
0.9.1, so JMS messages consumed from AMQP resources can have a null
value. This commit mitigates the issue by returning a timestamp set to 0
in this case, just like the JMS 1.1 specification suggests it when
MessageProducer#setDisableMessageTimestamp(true) is called.

Fixes #126