### PR TITLE
Fix AMQP resource creation in RMQObjectFactory

### DIFF
--- a/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
@@ -556,10 +556,22 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
      */
     @Override
     public Reference getReference() throws NamingException {
-        Reference ref = new Reference(RMQConnectionFactory.class.getName());
+        Reference ref = new Reference(RMQConnectionFactory.class.getName(), RMQObjectFactory.class.getName(), null);
         addStringRefProperty(ref, "uri", this.getUri());
+        addStringRefProperty(ref, "host", this.getHost());
+        addStringRefProperty(ref, "password", this.getPassword());
+        addIntegerRefProperty(ref, "port", this.getPort());
         addIntegerRefProperty(ref, "queueBrowserReadMax", this.getQueueBrowserReadMax());
         addIntegerRefProperty(ref, "onMessageTimeoutMs", this.getOnMessageTimeoutMs());
+        addIntegerRefProperty(ref, "channelsQos", this.getChannelsQos());
+        addBooleanProperty(ref, "ssl", this.ssl);
+        addLongRefProperty(ref, "terminationTimeout", this.getTerminationTimeout());
+        addStringRefProperty(ref, "username", this.getUsername());
+        addStringRefProperty(ref, "virtualHost", this.getVirtualHost());
+        addBooleanProperty(ref, "cleanUpServerNamedQueuesForNonDurableTopicsOnSessionClose",
+                this.isCleanUpServerNamedQueuesForNonDurableTopicsOnSessionClose());
+        addBooleanProperty(ref, "declareReplyToDestination",
+                this.declareReplyToDestination);
         return ref;
     }
 
@@ -587,6 +599,35 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
                                               String propertyName,
                                               Integer value) {
         if (value == null || propertyName == null) return;
+        RefAddr ra = new StringRefAddr(propertyName, String.valueOf(value));
+        ref.add(ra);
+    }
+
+    /**
+     * Adds an long valued property to a Reference (as a RefAddr).
+     * @param ref - the reference to contain the value
+     * @param propertyName - the name of the property
+     * @param value - the value to store with the property
+     */
+    private static void addLongRefProperty(Reference ref,
+                                              String propertyName,
+                                              Long value) {
+        if (value == null || propertyName == null) return;
+        RefAddr ra = new StringRefAddr(propertyName, String.valueOf(value));
+        ref.add(ra);
+    }
+
+    /**
+     * Adds a boolean valued property to a Reference (as a StringRefAddr) if the value is <code>true</code>
+     * (default <code>false</code> on read assumed).
+     * @param ref - the reference to contain the value
+     * @param propertyName - the name of the property
+     * @param value - the value to store with the property
+     */
+    private static final void addBooleanProperty(Reference ref,
+                                                 String propertyName,
+                                                 boolean value) {
+        if (propertyName==null) return;
         RefAddr ra = new StringRefAddr(propertyName, String.valueOf(value));
         ref.add(ra);
     }

--- a/src/main/java/com/rabbitmq/jms/admin/RMQDestination.java
+++ b/src/main/java/com/rabbitmq/jms/admin/RMQDestination.java
@@ -260,7 +260,7 @@ public class RMQDestination implements Queue, Topic, Destination, Referenceable,
 
     @Override
     public Reference getReference() throws NamingException {
-        Reference ref = new Reference(this.getClass().getCanonicalName());
+        Reference ref = new Reference(this.getClass().getCanonicalName(), RMQObjectFactory.class.getName(), null);
         addStringProperty(ref, "destinationName", this.destinationName);
         addBooleanProperty(ref, "amqp", this.amqp);
         addBooleanProperty(ref, "isQueue", this.isQueue);

--- a/src/main/java/com/rabbitmq/jms/admin/RMQObjectFactory.java
+++ b/src/main/java/com/rabbitmq/jms/admin/RMQObjectFactory.java
@@ -143,8 +143,10 @@ public class RMQObjectFactory implements ObjectFactory {
          * javax.jms.ConnectionFactory
          * javax.jms.QueueConnectionFactory
          * javax.jms.TopicConnectionFactory
+         * com.rabbitmq.jms.admin.RMQConnectionFactory
          * javax.jms.Topic
          * javax.jms.Queue
+         * com.rabbitmq.jms.admin.RMQDestination
          *
          */
         boolean topic = false;
@@ -152,11 +154,14 @@ public class RMQObjectFactory implements ObjectFactory {
         if (  javax.jms.QueueConnectionFactory.class.getName().equals(className)
            || javax.jms.TopicConnectionFactory.class.getName().equals(className)
            || javax.jms.ConnectionFactory.class.getName().equals(className)
+           || RMQConnectionFactory.class.getName().equals(className)
            ) {
             connectionFactory = true;
         } else if (javax.jms.Topic.class.getName().equals(className)) {
             topic = true;
         } else if (javax.jms.Queue.class.getName().equals(className)) {
+        } else if (RMQDestination.class.getName().equals(className)) {
+            topic = !getBooleanProperty(ref, environment, "isQueue", true, false);
         } else {
             throw new NamingException(String.format("Unknown class [%s]", className));
         }

--- a/src/main/java/com/rabbitmq/jms/admin/RMQObjectFactory.java
+++ b/src/main/java/com/rabbitmq/jms/admin/RMQObjectFactory.java
@@ -227,9 +227,9 @@ public class RMQObjectFactory implements ObjectFactory {
         String dname = getStringProperty(ref, environment, "destinationName", false, null);
         boolean amqp = getBooleanProperty(ref, environment, "amqp", true, false);
         if (amqp) {
-            String amqpExchangeName = getStringProperty(ref, environment, "amqpExchangeName", false, null);
-            String amqpRoutingKey = getStringProperty(ref, environment,"amqpRoutingKey", false, null);
-            String amqpQueueName = getStringProperty(ref, environment, "amqpQueueName", false, null);
+            String amqpExchangeName = getStringProperty(ref, environment, "amqpExchangeName", true, null);
+            String amqpRoutingKey = getStringProperty(ref, environment,"amqpRoutingKey", true, null);
+            String amqpQueueName = getStringProperty(ref, environment, "amqpQueueName", true, null);
             return new RMQDestination(dname, amqpExchangeName, amqpRoutingKey, amqpQueueName);
         } else {
             return new RMQDestination(dname, !topic, false);

--- a/src/test/java/com/rabbitmq/jms/admin/RMQDestinationTest.java
+++ b/src/test/java/com/rabbitmq/jms/admin/RMQDestinationTest.java
@@ -1,0 +1,49 @@
+/* Copyright (c) 2020 VMware, Inc. or its affiliates. All rights reserved. */
+package com.rabbitmq.jms.admin;
+
+import org.junit.jupiter.api.Test;
+
+import javax.naming.Reference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RMQDestinationTest {
+
+    RMQObjectFactory rmqObjectFactory = new RMQObjectFactory();
+
+    @Test
+    void queueRegeneration() throws Exception {
+        RMQDestination queue = new RMQDestination("queue", true, false);
+        Reference reference = queue.getReference();
+        RMQDestination newQueue = (RMQDestination) rmqObjectFactory.getObjectInstance(reference, null, null, null);
+        assertThat(newQueue.isQueue()).isTrue();
+        assertThat(newQueue.getDestinationName()).isEqualTo("queue");
+        assertThat(newQueue.isAmqp()).isFalse();
+    }
+
+    @Test
+    void topicRegeneration() throws Exception {
+        RMQDestination topic = new RMQDestination("topic", false, false);
+        Reference reference = topic.getReference();
+        RMQDestination newTopic = (RMQDestination) rmqObjectFactory.getObjectInstance(reference, null, null, null);
+        assertThat(newTopic.isQueue()).isFalse();
+        assertThat(newTopic.getDestinationName()).isEqualTo("topic");
+        assertThat(newTopic.isAmqp()).isFalse();
+    }
+
+    @Test
+    void amqpDestinationRegeneration() throws Exception {
+        RMQDestination destination = new RMQDestination(
+                "destination", "exchange", "routing-key", "queue"
+        );
+        Reference reference = destination.getReference();
+        RMQDestination newReference = (RMQDestination) rmqObjectFactory.getObjectInstance(reference, null, null, null);
+        assertThat(newReference.isQueue()).isTrue();
+        assertThat(newReference.getDestinationName()).isEqualTo("destination");
+        assertThat(newReference.isAmqp()).isTrue();
+        assertThat(newReference.getAmqpExchangeName()).isEqualTo("exchange");
+        assertThat(newReference.getAmqpRoutingKey()).isEqualTo("routing-key");
+        assertThat(newReference.getAmqpQueueName()).isEqualTo("queue");
+    }
+
+}

--- a/src/test/java/com/rabbitmq/jms/admin/RMQDestinationTest.java
+++ b/src/test/java/com/rabbitmq/jms/admin/RMQDestinationTest.java
@@ -46,4 +46,34 @@ public class RMQDestinationTest {
         assertThat(newReference.getAmqpQueueName()).isEqualTo("queue");
     }
 
+    @Test
+    void amqpDestinationExchangeRoutingKeyOnlyRegeneration() throws Exception {
+        RMQDestination destination = new RMQDestination(
+                "destination", "exchange", "routing-key", null
+        );
+        Reference reference = destination.getReference();
+        RMQDestination newReference = (RMQDestination) rmqObjectFactory.getObjectInstance(reference, null, null, null);
+        assertThat(newReference.isQueue()).isTrue();
+        assertThat(newReference.getDestinationName()).isEqualTo("destination");
+        assertThat(newReference.isAmqp()).isTrue();
+        assertThat(newReference.getAmqpExchangeName()).isEqualTo("exchange");
+        assertThat(newReference.getAmqpRoutingKey()).isEqualTo("routing-key");
+        assertThat(newReference.getAmqpQueueName()).isNull();
+    }
+
+    @Test
+    void amqpDestinationQueueOnlyRegeneration() throws Exception {
+        RMQDestination destination = new RMQDestination(
+                "destination", null, null, "queue"
+        );
+        Reference reference = destination.getReference();
+        RMQDestination newReference = (RMQDestination) rmqObjectFactory.getObjectInstance(reference, null, null, null);
+        assertThat(newReference.isQueue()).isTrue();
+        assertThat(newReference.getDestinationName()).isEqualTo("destination");
+        assertThat(newReference.isAmqp()).isTrue();
+        assertThat(newReference.getAmqpExchangeName()).isNull();
+        assertThat(newReference.getAmqpRoutingKey()).isNull();
+        assertThat(newReference.getAmqpQueueName()).isEqualTo("queue");
+    }
+
 }

--- a/src/test/java/com/rabbitmq/jms/admin/RMQObjectFactoryTest.java
+++ b/src/test/java/com/rabbitmq/jms/admin/RMQObjectFactoryTest.java
@@ -91,7 +91,7 @@ public class RMQObjectFactoryTest {
 
 
     @Test
-    public void getObjectInstanceShouldCreateARMQDestinationTOPICViaEnvironment() throws Exception {
+    public void getObjectInstanceShouldCreateAMQPDestinationTOPICViaEnvironment() throws Exception {
 
         Hashtable<?, ?> environment = new Hashtable<Object, Object>() {{
             put("className", "javax.jms.Topic");
@@ -116,7 +116,6 @@ public class RMQObjectFactoryTest {
 
         Hashtable<?, ?> environment = new Hashtable<Object, Object>() {{
             put("className", "javax.jms.Queue");
-            put("destinationName", "TEST_QUEUE");
             put("amqp", "true");
         }};
 
@@ -124,7 +123,7 @@ public class RMQObjectFactoryTest {
             rmqObjectFactory.getObjectInstance("anything but a javax.naming.Reference", new CompositeName("java:global/jms/TestConnectionFactory"), null, environment);
             fail("Should have thrown a NamingException");
         } catch (NamingException ne) {
-            assertEquals("Property [amqpExchangeName] may not be null.", ne.getMessage());
+            assertEquals("Property [destinationName] may not be null.", ne.getMessage());
         }
 
     }

--- a/src/test/java/com/rabbitmq/jms/admin/RMQObjectFactoryTest.java
+++ b/src/test/java/com/rabbitmq/jms/admin/RMQObjectFactoryTest.java
@@ -1,3 +1,4 @@
+/* Copyright (c) 2018-2020 VMware, Inc. or its affiliates. All rights reserved. */
 package com.rabbitmq.jms.admin;
 
 import org.junit.jupiter.api.Test;
@@ -21,7 +22,7 @@ public class RMQObjectFactoryTest {
     private RMQObjectFactory rmqObjectFactory = new RMQObjectFactory();
 
     @Test
-    public void getObjectInstanceShouldCreateARMQConnectionFactoryViaReference() throws Exception {
+    public void getObjectInstanceShouldCreateAMQPConnectionFactoryViaReference() throws Exception {
 
         Reference ref = new Reference(ConnectionFactory.class.getName());
 
@@ -42,7 +43,7 @@ public class RMQObjectFactoryTest {
 
 
     @Test
-    public void getObjectInstanceShouldCreateARMQConnectionFactoryViaEnvironment() throws Exception {
+    public void getObjectInstanceShouldCreateAMQPConnectionFactoryViaEnvironment() throws Exception {
 
         Hashtable<?, ?> environment = new Hashtable<Object, Object>() {{
             put("className", "javax.jms.ConnectionFactory");
@@ -69,7 +70,7 @@ public class RMQObjectFactoryTest {
     }
 
     @Test
-    public void getObjectInstanceShouldCreateARMQDestinationQUEUEViaEnvironment() throws Exception {
+    public void getObjectInstanceShouldCreateAMQPDestinationQUEUEViaEnvironment() throws Exception {
 
         Hashtable<?, ?> environment = new Hashtable<Object, Object>() {{
             put("className", "javax.jms.Queue");


### PR DESCRIPTION
The exchange/routing key/queue properties were all marked as non-nullable, whereas
they can be null. The RMQDestination constructor takes care of checking
the arguments.
    
Fixes #129