### PR TITLE
Add RMQSession#addShutdownListenerToChannel method

### DIFF
--- a/src/main/java/com/rabbitmq/jms/client/RMQSession.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQSession.java
@@ -51,6 +51,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.ShutdownListener;
 import com.rabbitmq.client.ShutdownSignalException;
 import com.rabbitmq.jms.admin.RMQDestination;
 import com.rabbitmq.jms.client.message.RMQBytesMessage;
@@ -392,6 +393,10 @@ public class RMQSession implements Session, QueueSession, TopicSession {
     public int getAcknowledgeMode() throws JMSException {
         illegalStateExceptionIfClosed();
         return getAcknowledgeModeNoException();
+    }
+
+    public void addShutdownListenerToChannel(ShutdownListener shutdownListener) {
+        this.channel.addShutdownListener(shutdownListener);
     }
 
     public List<String> getTrustedPackages() {


### PR DESCRIPTION
Hi RabbitMQ JMS Team,

I'd like to add `RMQSession#addShutdownListenerToChannel` method.
This will allow users to add their own customized ShutdownListener which could be used for recovering closed RMQSession.

Our use case specifically is when Session is closed due to `MessageListener#onMessage` taking too long (timeout), there is no way to catch exception and recreate Session because it is handled internally in different thread. By using `RMQSession#addShutdownListenerToChannel` method, we can detect session closure and recover if necessary.

Please let me know what you guys think :)

Best,
Edmund