### PR TITLE
Use trusted packages in StreamMessage

### DIFF
--- a/src/main/java/com/rabbitmq/jms/client/RMQMessage.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQMessage.java
@@ -1146,6 +1146,8 @@ public abstract class RMQMessage implements Message, Cloneable {
     private static RMQMessage instantiateRmqMessage(String messageClass, List<String> trustedPackages) throws RMQJMSException {
         if(isRmqObjectMessageClass(messageClass)) {
             return instantiateRmqObjectMessageWithTrustedPackages(trustedPackages);
+        } else if (isRmqStreamMessageClass(messageClass)) {
+            return instantiateRmqStreamMessageWithTrustedPackages(trustedPackages);
         } else {
             try {
                 // instantiate the message object with the thread context classloader
@@ -1168,12 +1170,24 @@ public abstract class RMQMessage implements Message, Cloneable {
         return RMQObjectMessage.class.getName().equals(clazz);
     }
 
+    private static boolean isRmqStreamMessageClass(String clazz) {
+        return RMQStreamMessage.class.getName().equals(clazz);
+    }
+
     private static RMQObjectMessage instantiateRmqObjectMessageWithTrustedPackages(List<String> trustedPackages) throws RMQJMSException {
+        return (RMQObjectMessage) instantiateRmqMessageWithTrustedPackages(RMQObjectMessage.class.getName(), trustedPackages);
+    }
+
+    private static RMQStreamMessage instantiateRmqStreamMessageWithTrustedPackages(List<String> trustedPackages) throws RMQJMSException {
+        return (RMQStreamMessage) instantiateRmqMessageWithTrustedPackages(RMQStreamMessage.class.getName(), trustedPackages);
+    }
+
+    private static RMQMessage instantiateRmqMessageWithTrustedPackages(String messageClazz, List<String> trustedPackages) throws RMQJMSException {
         try {
             // instantiate the message object with the thread context classloader
-            Class<?> messageClass = Class.forName(RMQObjectMessage.class.getName(), true, Thread.currentThread().getContextClassLoader());
+            Class<?> messageClass = Class.forName(messageClazz, true, Thread.currentThread().getContextClassLoader());
             Constructor<?> constructor = messageClass.getConstructor(List.class);
-            return (RMQObjectMessage) constructor.newInstance(trustedPackages);
+            return (RMQMessage) constructor.newInstance(trustedPackages);
         } catch (NoSuchMethodException e) {
             throw new RMQJMSException(e);
         } catch (InvocationTargetException e) {

--- a/src/main/java/com/rabbitmq/jms/client/message/RMQStreamMessage.java
+++ b/src/main/java/com/rabbitmq/jms/client/message/RMQStreamMessage.java
@@ -5,6 +5,7 @@
 // Copyright (c) 2013-2020 VMware, Inc. or its affiliates. All rights reserved.
 package com.rabbitmq.jms.client.message;
 
+import com.rabbitmq.jms.util.WhiteListObjectInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.EOFException;
@@ -15,6 +16,7 @@ import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
 import java.io.UTFDataFormatException;
 
+import java.util.List;
 import javax.jms.JMSException;
 import javax.jms.MessageEOFException;
 import javax.jms.MessageFormatException;
@@ -47,12 +49,19 @@ public class RMQStreamMessage extends RMQMessage implements StreamMessage {
     private volatile transient byte[] buf;
     private volatile transient byte[] readbuf = null;
 
-    public RMQStreamMessage() {
-        this(false);
+    private final List<String> trustedPackages;
+
+    public RMQStreamMessage(List<String> trustedPackages) {
+        this(false, trustedPackages);
     }
 
-    private RMQStreamMessage(boolean reading) {
+    public RMQStreamMessage() {
+        this(false, WhiteListObjectInputStream.DEFAULT_TRUSTED_PACKAGES);
+    }
+
+    private RMQStreamMessage(boolean reading, List<String> trustedPackages) {
         this.reading = reading;
+        this.trustedPackages = trustedPackages;
         if (!reading) {
             this.bout = new ByteArrayOutputStream(RMQMessage.DEFAULT_MESSAGE_BODY_SIZE);
             try {
@@ -513,7 +522,7 @@ public class RMQStreamMessage extends RMQMessage implements StreamMessage {
         inputStream.read(buf);
         this.reading = true;
         this.bin = new ByteArrayInputStream(buf);
-        this.in = new ObjectInputStream(this.bin);
+        this.in = new WhiteListObjectInputStream(this.bin, this.trustedPackages);
     }
 
     @Override

--- a/src/test/java/com/rabbitmq/integration/tests/StreamMessageSerializationIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/StreamMessageSerializationIT.java
@@ -5,28 +5,30 @@
 // Copyright (c) 2013-2020 VMware, Inc. or its affiliates. All rights reserved.
 package com.rabbitmq.integration.tests;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import com.rabbitmq.jms.admin.RMQConnectionFactory;
-import com.rabbitmq.jms.client.message.RMQObjectMessage;
+import com.rabbitmq.jms.client.message.RMQStreamMessage;
 import com.rabbitmq.jms.client.message.TestMessages;
 import com.rabbitmq.jms.util.RMQJMSException;
-import org.junit.jupiter.api.Test;
-
+import java.awt.Color;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import javax.jms.Queue;
 import javax.jms.QueueReceiver;
 import javax.jms.QueueSender;
 import javax.jms.QueueSession;
 import javax.jms.Session;
-import java.awt.*;
-import java.io.Serializable;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
+import javax.jms.StreamMessage;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+public class StreamMessageSerializationIT extends AbstractITQueue {
 
-public class ObjectMessageSerializationIT extends AbstractITQueue {
-
-    private static final String QUEUE_NAME = "test.queue." + ObjectMessageSerializationIT.class.getCanonicalName();
+    private static final String QUEUE_NAME = "test.queue." + StreamMessageSerializationIT.class.getCanonicalName();
     private static final long TEST_RECEIVE_TIMEOUT = 1000; // one second
     private static final java.util.List<String> TRUSTED_PACKAGES = Arrays.asList("java.lang", "com.rabbitmq.jms");
 
@@ -36,7 +38,7 @@ public class ObjectMessageSerializationIT extends AbstractITQueue {
         connectionFactory.setTrustedPackages(TRUSTED_PACKAGES);
     }
 
-    protected void testReceiveObjectMessageWithPayload(Object payload) throws Exception {
+    protected void testReceiveStreamMessageWithValue(Object value) throws Exception {
         try {
             queueConn.start();
             QueueSession queueSession = queueConn.createQueueSession(false, Session.DUPS_OK_ACKNOWLEDGE);
@@ -45,7 +47,18 @@ public class ObjectMessageSerializationIT extends AbstractITQueue {
             drainQueue(queueSession, queue);
 
             QueueSender queueSender = queueSession.createSender(queue);
-            queueSender.send(MessageTestType.OBJECT.gen(queueSession, (Serializable) payload));
+            StreamMessage message = (StreamMessage) MessageTestType.STREAM.gen(queueSession, null);
+
+            // we simulate an attack from the sender by calling writeObject with a non-primitive value
+            // (StreamMessage supports only primitive types)
+            // the value is then sent to the destination and the consumer will have to
+            // deserialize it and can potentially execute malicious code
+            Method writeObjectMethod = RMQStreamMessage.class
+                .getDeclaredMethod("writeObject", Object.class, boolean.class);
+            writeObjectMethod.setAccessible(true);
+            writeObjectMethod.invoke(message, value, true);
+
+            queueSender.send(message);
         } finally {
             reconnect(Arrays.asList("java.lang", "com.rabbitmq.jms"));
         }
@@ -54,38 +67,40 @@ public class ObjectMessageSerializationIT extends AbstractITQueue {
         QueueSession queueSession = queueConn.createQueueSession(false, Session.DUPS_OK_ACKNOWLEDGE);
         Queue queue = queueSession.createQueue(QUEUE_NAME);
         QueueReceiver queueReceiver = queueSession.createReceiver(queue);
-        RMQObjectMessage m = (RMQObjectMessage) queueReceiver.receive(TEST_RECEIVE_TIMEOUT);
-        assertEquals(m.getObject(), payload);
-        assertEquals(m.getObject(TRUSTED_PACKAGES), payload);
+        RMQStreamMessage m = (RMQStreamMessage) queueReceiver.receive(TEST_RECEIVE_TIMEOUT);
+        MessageTestType.STREAM.check(m, null);
+        assertEquals(m.readObject(), value);
     }
 
     @Test
-    public void testReceiveObjectMessageWithPrimitivePayload() throws Exception {
-        testReceiveObjectMessageWithPayload(1024L);
-        testReceiveObjectMessageWithPayload("a string");
+    public void testReceiveStreamMessageWithPrimitiveValue() throws Exception {
+        testReceiveStreamMessageWithValue(1024L);
+        testReceiveStreamMessageWithValue("a string");
     }
 
     @Test
-    public void testReceiveObjectMessageWithTrustedPayload() throws Exception {
-        testReceiveObjectMessageWithPayload(new TestMessages.TestSerializable(8, "An object"));
+    public void testReceiveStreamMessageWithTrustedValue() throws Exception {
+        testReceiveStreamMessageWithValue(new TestMessages.TestSerializable(8, "An object"));
     }
 
     @Test
-    public void testReceiveObjectMessageWithUntrustedPayload1() throws Exception {
-        // It makes little sense to use ObjectMessage for maps
-        // but someone somewhere certainly does it.
+    public void testReceiveStreamMessageWithUntrustedValue1() throws Exception {
+        // StreamMessage cannot be used with a Map, unless the sender uses a trick
+        // this is to simulate an attack from the sender
         // Note: java.util is not on the trusted package list
         assertThrows(RMQJMSException.class, () -> {
             Map<String, String> m = new HashMap<String, String>();
             m.put("key", "value");
-            testReceiveObjectMessageWithPayload(m);
+            testReceiveStreamMessageWithValue(m);
         });
     }
     @Test
-    public void testReceiveObjectMessageWithUntrustedPayload2() throws Exception {
+    public void testReceiveStreamMessageWithUntrustedValue2() throws Exception {
+        // StreamMessage cannot be used with a Map, unless the sender uses a trick
+        // this is to simulate an attack from the sender
         // java.awt is not on the trusted package list
         assertThrows(RMQJMSException.class, () -> {
-            testReceiveObjectMessageWithPayload(Color.WHITE);
+            testReceiveStreamMessageWithValue(Color.WHITE);
         });
     }
 


### PR DESCRIPTION
StreamMessage now uses the same "white list" mechanism as
ObjectMessage to avoid some arbitrary code execution on deserialization.

Even though StreamMessage is supposed to handle only primitive types,
it is still to possible to send a message that contains an arbitrary
serializable instance. The consuming application application may
then execute code from this class on deserialization.

The fix consists in using the list of trusted packages that can be
set at the connection factory level.

Fixes #135