### PR TITLE
Add autoJmsTypeHeaderForTextMessages property

### DIFF
--- a/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2013-2021 VMware, Inc. or its affiliates. All rights reserved. */
+/* Copyright (c) 2013-2022 VMware, Inc. or its affiliates. All rights reserved. */
 package com.rabbitmq.jms.admin;
 
 import com.rabbitmq.client.AMQP;
@@ -160,6 +160,8 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
      */
     private ConfirmListener confirmListener;
 
+    private boolean autoJmsTypeHeaderForTextMessages = false;
+
 
     /** Default not to use ssl */
     private boolean ssl = false;
@@ -290,6 +292,7 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
             .setConfirmListener(confirmListener)
             .setTrustedPackages(this.trustedPackages)
             .setRequeueOnTimeout(this.requeueOnTimeout)
+            .setAutoJmsTypeHeaderForTextMessages(this.autoJmsTypeHeaderForTextMessages)
         );
         logger.debug("Connection {} created.", conn);
         return conn;
@@ -1034,6 +1037,10 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
         this.requeueOnTimeout = requeueOnTimeout;
     }
 
+    public void setAutoJmsTypeHeaderForTextMessages(boolean autoJmsTypeHeaderForTextMessages) {
+        this.autoJmsTypeHeaderForTextMessages = autoJmsTypeHeaderForTextMessages;
+    }
+
     @FunctionalInterface
     private interface ConnectionCreator {
         com.rabbitmq.client.Connection create(com.rabbitmq.client.ConnectionFactory cf) throws Exception;
@@ -1128,4 +1135,3 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
         public void accept(ReceivingContext receivingContext) { }
     }
 }
-

--- a/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
@@ -1,21 +1,25 @@
 /* Copyright (c) 2013-2022 VMware, Inc. or its affiliates. All rights reserved. */
 package com.rabbitmq.jms.admin;
 
+import static com.rabbitmq.jms.util.UriCodec.encHost;
+import static com.rabbitmq.jms.util.UriCodec.encSegment;
+import static com.rabbitmq.jms.util.UriCodec.encUserinfo;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Address;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.MetricsCollector;
-import com.rabbitmq.jms.client.*;
+import com.rabbitmq.jms.client.ConfirmListener;
+import com.rabbitmq.jms.client.ConnectionParams;
+import com.rabbitmq.jms.client.RMQConnection;
+import com.rabbitmq.jms.client.RMQMessage;
+import com.rabbitmq.jms.client.ReceivingContext;
+import com.rabbitmq.jms.client.ReceivingContextConsumer;
+import com.rabbitmq.jms.client.SendingContext;
+import com.rabbitmq.jms.client.SendingContextConsumer;
 import com.rabbitmq.jms.util.RMQJMSException;
 import com.rabbitmq.jms.util.RMQJMSSecurityException;
 import com.rabbitmq.jms.util.WhiteListObjectInputStream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.jms.*;
-import javax.naming.*;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLException;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.URI;
@@ -27,8 +31,28 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-
-import static com.rabbitmq.jms.util.UriCodec.*;
+import javax.jms.BytesMessage;
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import javax.jms.MessageProducer;
+import javax.jms.QueueConnection;
+import javax.jms.QueueConnectionFactory;
+import javax.jms.TextMessage;
+import javax.jms.TopicConnection;
+import javax.jms.TopicConnectionFactory;
+import javax.naming.NamingException;
+import javax.naming.RefAddr;
+import javax.naming.Reference;
+import javax.naming.Referenceable;
+import javax.naming.StringRefAddr;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * RabbitMQ Implementation of JMS {@link ConnectionFactory}
@@ -160,8 +184,21 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
      */
     private ConfirmListener confirmListener;
 
+    /**
+     * Flag to insert automatically an interoperability hint in outbound {@link TextMessage}s.
+     *
+     * <p>When set to <code>true</code>, the AMQP <code>JMSType</code> header will be set
+     * automatically to <code>"TextMessage"</code> for {@link TextMessage}s published to AMQP-backed
+     * {@link Destination}s. This way JMS consumers will receive {@link TextMessage}s instead of
+     * {@link BytesMessage}.
+     *
+     * <p>Enabling the feature avoids some additional work in the application code of publishers.
+     *
+     * <p>The default is false.
+     *
+     * @since 2.5.0
+     */
     private boolean autoJmsTypeHeaderForTextMessages = false;
-
 
     /** Default not to use ssl */
     private boolean ssl = false;

--- a/src/main/java/com/rabbitmq/jms/admin/RMQObjectFactory.java
+++ b/src/main/java/com/rabbitmq/jms/admin/RMQObjectFactory.java
@@ -226,6 +226,7 @@ public class RMQObjectFactory implements ObjectFactory {
         f.setVirtualHost        (getStringProperty (ref, environment, "virtualHost",         true, f.getVirtualHost()        ));
         f.setCleanUpServerNamedQueuesForNonDurableTopicsOnSessionClose(getBooleanProperty(ref, environment, "cleanUpServerNamedQueuesForNonDurableTopicsOnSessionClose",                 true, f.isCleanUpServerNamedQueuesForNonDurableTopicsOnSessionClose()                 ));
         f.setDeclareReplyToDestination(getBooleanProperty(ref, environment, "declareReplyToDestination", true, true));
+        f.setAutoJmsTypeHeaderForTextMessages(getBooleanProperty(ref, environment, "autoJmsTypeHeaderForTextMessages", true, false));
         return f;
     }
 

--- a/src/main/java/com/rabbitmq/jms/client/ConnectionParams.java
+++ b/src/main/java/com/rabbitmq/jms/client/ConnectionParams.java
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2016-2021 VMware, Inc. or its affiliates. All rights reserved.
+// Copyright (c) 2016-2022 VMware, Inc. or its affiliates. All rights reserved.
 package com.rabbitmq.jms.client;
 
 import com.rabbitmq.client.AMQP;
@@ -112,6 +112,8 @@ public class ConnectionParams {
      * @since 1.13.0
      */
     private ConfirmListener confirmListener;
+
+    private boolean autoJmsTypeHeaderForTextMessages = false;
 
     private List<String> trustedPackages = WhiteListObjectInputStream.DEFAULT_TRUSTED_PACKAGES;
 
@@ -230,6 +232,15 @@ public class ConnectionParams {
 
     public ConfirmListener getConfirmListener() {
         return confirmListener;
+    }
+
+    public ConnectionParams setAutoJmsTypeHeaderForTextMessages(boolean autoJmsTypeHeaderForTextMessages) {
+        this.autoJmsTypeHeaderForTextMessages = autoJmsTypeHeaderForTextMessages;
+        return this;
+    }
+
+    public boolean isAutoJmsTypeHeaderForTextMessages() {
+        return autoJmsTypeHeaderForTextMessages;
     }
 
     public ConnectionParams setTrustedPackages(List<String> trustedPackages) {

--- a/src/main/java/com/rabbitmq/jms/client/RMQConnection.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQConnection.java
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2013-2021 VMware, Inc. or its affiliates. All rights reserved.
+// Copyright (c) 2013-2022 VMware, Inc. or its affiliates. All rights reserved.
 package com.rabbitmq.jms.client;
 
 import java.io.IOException;
@@ -158,6 +158,8 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
      */
     private final List<String> trustedPackages;
 
+    private final boolean autoJmsTypeHeaderForTextMessages;
+
     /**
      * Creates an RMQConnection object.
      * @param connectionParams parameters for this connection
@@ -184,6 +186,7 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
         this.confirmListener = connectionParams.getConfirmListener();
         this.trustedPackages = connectionParams.getTrustedPackages();
         this.requeueOnTimeout = connectionParams.willRequeueOnTimeout();
+        this.autoJmsTypeHeaderForTextMessages = connectionParams.isAutoJmsTypeHeaderForTextMessages();
     }
 
     /**
@@ -239,6 +242,7 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
             .setConfirmListener(this.confirmListener)
             .setTrustedPackages(this.trustedPackages)
             .setRequeueOnTimeout(this.requeueOnTimeout)
+            .setAutoJmsTypeHeaderForTextMessages(this.autoJmsTypeHeaderForTextMessages)
         );
         this.sessions.add(session);
         return session;

--- a/src/main/java/com/rabbitmq/jms/client/RMQSession.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQSession.java
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2013-2021 VMware, Inc. or its affiliates. All rights reserved.
+// Copyright (c) 2013-2022 VMware, Inc. or its affiliates. All rights reserved.
 package com.rabbitmq.jms.client;
 
 import java.io.IOException;
@@ -191,12 +191,12 @@ public class RMQSession implements Session, QueueSession, TopicSession {
 
     private static Map<String, SqlExpressionType> generateJMSTypeIdents() {
         Map<String, SqlExpressionType> map = new HashMap<String, SqlExpressionType>(6);  // six elements only
-        map.put("JMSDeliveryMode",  SqlExpressionType.STRING);
-        map.put("JMSPriority",      SqlExpressionType.ARITH );
-        map.put("JMSMessageID",     SqlExpressionType.STRING);
-        map.put("JMSTimestamp",     SqlExpressionType.ARITH );
-        map.put("JMSCorrelationID", SqlExpressionType.STRING);
-        map.put("JMSType",          SqlExpressionType.STRING);
+        map.put("JMSDeliveryMode",          SqlExpressionType.STRING);
+        map.put("JMSPriority",              SqlExpressionType.ARITH );
+        map.put("JMSMessageID",             SqlExpressionType.STRING);
+        map.put("JMSTimestamp",             SqlExpressionType.ARITH );
+        map.put("JMSCorrelationID",         SqlExpressionType.STRING);
+        map.put(RMQMessage.JMS_TYPE_HEADER, SqlExpressionType.STRING);
         return Collections.unmodifiableMap(map);
     }
     static final Map<String, SqlExpressionType> JMS_TYPE_IDENTS = generateJMSTypeIdents();
@@ -222,6 +222,8 @@ public class RMQSession implements Session, QueueSession, TopicSession {
      * @since 1.14.0
      */
     private Map<String, Object> queueDeclareArguments = null;
+
+    private final boolean autoJmsTypeHeaderForTextMessages;
 
     /**
      * Creates a session object associated with a connection
@@ -250,6 +252,7 @@ public class RMQSession implements Session, QueueSession, TopicSession {
             ReceivingContextConsumer.NO_OP : sessionParams.getReceivingContextConsumer();
         this.trustedPackages = sessionParams.getTrustedPackages();
         this.requeueOnTimeout = sessionParams.willRequeueOnTimeout();
+        this.autoJmsTypeHeaderForTextMessages = sessionParams.isAutoJmsTypeHeaderForTextMessages();
 
         if (transacted) {
             this.acknowledgeMode = Session.SESSION_TRANSACTED;
@@ -685,7 +688,8 @@ public class RMQSession implements Session, QueueSession, TopicSession {
         RMQDestination dest = (RMQDestination) destination;
         declareDestinationIfNecessary(dest);
         RMQMessageProducer producer = new RMQMessageProducer(this, dest, this.preferProducerMessageProperty,
-            this.amqpPropertiesCustomiser, this.sendingContextConsumer, this.publishingListener);
+            this.amqpPropertiesCustomiser, this.sendingContextConsumer, this.publishingListener,
+            this.autoJmsTypeHeaderForTextMessages);
         this.producers.add(producer);
         return producer;
     }

--- a/src/main/java/com/rabbitmq/jms/client/SessionParams.java
+++ b/src/main/java/com/rabbitmq/jms/client/SessionParams.java
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2016-2021 VMware, Inc. or its affiliates. All rights reserved.
+// Copyright (c) 2016-2022 VMware, Inc. or its affiliates. All rights reserved.
 package com.rabbitmq.jms.client;
 
 import com.rabbitmq.client.AMQP;
@@ -108,6 +108,8 @@ public class SessionParams {
      * @since 1.13.0
      */
     private ConfirmListener confirmListener;
+
+    private boolean autoJmsTypeHeaderForTextMessages = false;
 
     private List<String> trustedPackages = WhiteListObjectInputStream.DEFAULT_TRUSTED_PACKAGES;
 
@@ -226,6 +228,15 @@ public class SessionParams {
 
     public ConfirmListener getConfirmListener() {
         return confirmListener;
+    }
+
+    public SessionParams setAutoJmsTypeHeaderForTextMessages(boolean autoJmsTypeHeaderForTextMessages) {
+        this.autoJmsTypeHeaderForTextMessages = autoJmsTypeHeaderForTextMessages;
+        return this;
+    }
+
+    public boolean isAutoJmsTypeHeaderForTextMessages() {
+        return autoJmsTypeHeaderForTextMessages;
     }
 
     public SessionParams setTrustedPackages(List<String> trustedPackages) {

--- a/src/test/java/com/rabbitmq/integration/tests/JmsTypeHeaderAutomaticallySetIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/JmsTypeHeaderAutomaticallySetIT.java
@@ -65,7 +65,6 @@ public class JmsTypeHeaderAutomaticallySetIT {
   @Test
   void jmsTypeHeaderShouldNotBeSetIfOptionDisabled() throws Exception {
     this.connFactory = connectionFactory();
-    this.connFactory.setAutoJmsTypeHeaderForTextMessages(false);
     this.queueConn = connFactory.createQueueConnection();
 
     queueConn.start();

--- a/src/test/java/com/rabbitmq/integration/tests/JmsTypeHeaderAutomaticallySetIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/JmsTypeHeaderAutomaticallySetIT.java
@@ -1,0 +1,129 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2022 VMware, Inc. or its affiliates. All rights reserved.
+
+package com.rabbitmq.integration.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.jms.admin.RMQConnectionFactory;
+import com.rabbitmq.jms.admin.RMQDestination;
+import java.nio.charset.StandardCharsets;
+import javax.jms.BytesMessage;
+import javax.jms.DeliveryMode;
+import javax.jms.Message;
+import javax.jms.Queue;
+import javax.jms.QueueConnection;
+import javax.jms.QueueReceiver;
+import javax.jms.QueueSender;
+import javax.jms.QueueSession;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class JmsTypeHeaderAutomaticallySetIT {
+
+  private static final String QUEUE_NAME =
+      "test.queue." + JmsTypeHeaderAutomaticallySetIT.class.getCanonicalName();
+  private static final String MESSAGE = "Hello " + JmsTypeHeaderAutomaticallySetIT.class.getName();
+  private static final long TEST_RECEIVE_TIMEOUT = 1000; // one second
+  protected QueueConnection queueConn;
+  protected Connection rabbitConn;
+  protected Channel channel;
+  private RMQConnectionFactory connFactory;
+  private final ConnectionFactory rabbitConnFactory = new ConnectionFactory();
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    this.rabbitConn = rabbitConnFactory.newConnection();
+    this.channel = rabbitConn.createChannel();
+
+    channel.queueDeclare(
+        QUEUE_NAME,
+        false, // durable
+        false, // exclusive
+        false, // autoDelete
+        null // options
+        );
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    channel.queueDelete(QUEUE_NAME);
+    this.queueConn.close();
+    this.channel.close();
+    this.rabbitConn.close();
+  }
+
+  @Test
+  void jmsTypeHeaderShouldNotBeSetIfOptionDisabled() throws Exception {
+    this.connFactory = connectionFactory();
+    this.connFactory.setAutoJmsTypeHeaderForTextMessages(false);
+    this.queueConn = connFactory.createQueueConnection();
+
+    queueConn.start();
+    QueueSession queueSession = queueConn.createQueueSession(false, Session.DUPS_OK_ACKNOWLEDGE);
+    Queue queue = new RMQDestination(QUEUE_NAME, "", QUEUE_NAME, null);
+
+    QueueSender queueSender = queueSession.createSender(queue);
+    queueSender.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+
+    Message message = queueSession.createTextMessage(MESSAGE);
+
+    queueSender.send(message);
+    queueSession.close();
+
+    queueSession = queueConn.createQueueSession(false, Session.DUPS_OK_ACKNOWLEDGE);
+    queue = new RMQDestination(QUEUE_NAME, null, null, QUEUE_NAME);
+    QueueReceiver queueReceiver = queueSession.createReceiver(queue);
+    message = queueReceiver.receive(TEST_RECEIVE_TIMEOUT);
+
+    assertThat(message).isNotNull().isInstanceOf(BytesMessage.class);
+
+    BytesMessage msg = (BytesMessage) message;
+    byte [] body = new byte[(int) msg.getBodyLength()];
+    msg.readBytes(body);
+    assertThat(body).asString(StandardCharsets.UTF_8).isEqualTo(MESSAGE);
+  }
+
+  @Test
+  void jmsTypeHeaderShouldBeSetIfOptionEnabled() throws Exception {
+    this.connFactory = connectionFactory();
+    this.connFactory.setAutoJmsTypeHeaderForTextMessages(true);
+    this.queueConn = connFactory.createQueueConnection();
+
+    queueConn.start();
+    QueueSession queueSession = queueConn.createQueueSession(false, Session.DUPS_OK_ACKNOWLEDGE);
+    Queue queue = new RMQDestination(QUEUE_NAME, "", QUEUE_NAME, null);
+
+    QueueSender queueSender = queueSession.createSender(queue);
+    queueSender.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+
+    Message message = queueSession.createTextMessage(MESSAGE);
+
+    queueSender.send(message);
+    queueSession.close();
+
+    queueSession = queueConn.createQueueSession(false, Session.DUPS_OK_ACKNOWLEDGE);
+    queue = new RMQDestination(QUEUE_NAME, null, null, QUEUE_NAME);
+    QueueReceiver queueReceiver = queueSession.createReceiver(queue);
+    message = queueReceiver.receive(TEST_RECEIVE_TIMEOUT);
+
+    assertThat(message).isNotNull().isInstanceOf(TextMessage.class);
+
+    TextMessage msg = (TextMessage) message;
+    assertThat(msg.getText()).isEqualTo(MESSAGE);
+  }
+
+  private RMQConnectionFactory connectionFactory() throws Exception {
+    return (RMQConnectionFactory)
+        AbstractTestConnectionFactory.getTestConnectionFactory().getConnectionFactory();
+  }
+}

--- a/src/test/java/com/rabbitmq/jms/admin/RMQObjectFactoryTest.java
+++ b/src/test/java/com/rabbitmq/jms/admin/RMQObjectFactoryTest.java
@@ -2,10 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2018-2020 VMware, Inc. or its affiliates. All rights reserved.
+// Copyright (c) 2018-2022 VMware, Inc. or its affiliates. All rights reserved.
 package com.rabbitmq.jms.admin;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.jms.ConnectionFactory;
@@ -72,7 +71,23 @@ public class RMQObjectFactoryTest {
         assertEquals("/fake", createdConFactory.getVirtualHost());
         assertEquals("fakeHost", createdConFactory.getHost());
         assertEquals(10, createdConFactory.getChannelsQos());
+        assertThat(createdConFactory).hasFieldOrPropertyWithValue("autoJmsTypeHeaderForTextMessages", false);
 
+    }
+
+    @Test
+    public void autoJmsTypeHeaderForTextMessagesIsSetPropertyOnConnectionFactory() throws Exception {
+        Hashtable<?, ?> environment = new Hashtable<Object, Object>() {{
+            put("className", "javax.jms.ConnectionFactory");
+            put("autoJmsTypeHeaderForTextMessages", "true");
+        }};
+
+        Object createdObject = rmqObjectFactory.getObjectInstance("anything but a javax.naming.Reference", new CompositeName("java:global/jms/TestConnectionFactory"), null, environment);
+
+        assertNotNull(createdObject);
+        assertEquals(RMQConnectionFactory.class, createdObject.getClass());
+        RMQConnectionFactory createdConFactory = (RMQConnectionFactory) createdObject;
+        assertThat(createdConFactory).hasFieldOrPropertyWithValue("autoJmsTypeHeaderForTextMessages", true);
     }
 
     @Test


### PR DESCRIPTION
When this option is enabled, the JMSType AMQP header is
set to TextMessage automatically for JMS TextMessages published
to AMQP resources. This way those messages are directly converted
to TextMessages for JMS consumers (instead of BytesMessages).

This avoids changing application code for some use cases: consumers
do not have to do some painful conversion to read the text body from
BytesMessages, they get TextMessages directly. And publishers
do not have to worry about setting the header depending on the
type of destination ("pure" JMS or AMQP).

The property is also settable from JNDI, which allows changing the
types of destinations without changing application code.

The option is disabled by default, so backward compatibility is preserved.