### PR TITLE
Support Delayed messages 

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -12,12 +12,6 @@ jobs:
   build:
     runs-on: ubuntu-22.04
 
-    services:
-      rabbitmq:
-        image: rabbitmq
-        ports:
-          - 5672:5672
-
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK
@@ -26,11 +20,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
           cache: 'maven'
-      - name: Enable JMS Topic Exchange Plugin
-        run: docker exec ${{job.services.rabbitmq.id}} rabbitmq-plugins enable rabbitmq_jms_topic_exchange --offline
-      - name: Stop RabbitMQ application
-        run: docker exec ${{job.services.rabbitmq.id}} rabbitmqctl stop_app
       - name: Start RabbitMQ application
-        run: docker exec ${{job.services.rabbitmq.id}} rabbitmqctl start_app
+        run: bin/start_rabbitmq.sh
       - name: Test
-        run: ./mvnw verify -Drabbitmqctl.bin=DOCKER:${{job.services.rabbitmq.id}}
+        run: ./mvnw verify -Drabbitmqctl.bin=DOCKER:rabbitmq -Drabbitmq_plugins.bin=DOCKER:rabbitmq

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Start RabbitMQ application
         run: bin/start_rabbitmq.sh
       - name: Test
-        run: ./mvnw verify -Drabbitmqctl.bin=DOCKER:rabbitmq -Drabbitmq_plugins.bin=DOCKER:rabbitmq
+        run: ./mvnw verify -Drabbitmqctl.bin=DOCKER:rabbitmq

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ target/
 .settings
 .idea/*
 *.iml
+enabled_plugins
+*.ez

--- a/bin/start_rabbitmq.sh
+++ b/bin/start_rabbitmq.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+LOCAL_SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+RABBITMQ_IMAGE_TAG=${RABBITMQ_IMAGE_TAG:-3.11}
+RABBITMQ_IMAGE=${RABBITMQ_IMAGE:-rabbitmq}
+
+echo "Download required plugins"
+wget https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/3.11.1/rabbitmq_delayed_message_exchange-3.11.1.ez
+
+cat > ${PWD}/enabled_plugins << ENDOFFILE
+[rabbitmq_management,rabbitmq_jms_topic_exchange,rabbitmq_delayed_message_exchange].
+ENDOFFILE
+
+echo "Running RabbitMQ ${RABBITMQ_IMAGE}:${RABBITMQ_IMAGE_TAG}"
+
+docker rm -f rabbitmq 2>/dev/null || echo "rabbitmq was not running"
+docker run -d --name rabbitmq \
+    -p 15672:15672 -p 5672:5672 \
+    -v ${PWD}/enabled_plugins:/etc/rabbitmq/enabled_plugins \
+    -v ${PWD}/rabbitmq_delayed_message_exchange-3.11.1.ez:/opt/rabbitmq/plugins/rabbitmq_delayed_message_exchange-3.11.1.ez \
+    ${RABBITMQ_IMAGE}:${RABBITMQ_IMAGE_TAG}

--- a/bin/start_rabbitmq.sh
+++ b/bin/start_rabbitmq.sh
@@ -2,8 +2,16 @@
 
 LOCAL_SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-RABBITMQ_IMAGE_TAG=${RABBITMQ_IMAGE_TAG:-3.11}
-RABBITMQ_IMAGE=${RABBITMQ_IMAGE:-rabbitmq}
+RABBITMQ_IMAGE_TAG=${RABBITMQ_IMAGE_TAG:-3.11.0-rc.2.29.geee5757.dirty}
+RABBITMQ_IMAGE=${RABBITMQ_IMAGE:-pivotalrabbitmq/rabbitmq}
+
+wait_for_message() {
+  while ! docker logs $1 | grep -q "$2";
+  do
+      sleep 5
+      echo "Waiting 5sec for $1 to start ..."
+  done
+}
 
 echo "Download required plugins"
 wget https://github.com/rabbitmq/rabbitmq-delayed-message-exchange/releases/download/3.11.1/rabbitmq_delayed_message_exchange-3.11.1.ez
@@ -20,3 +28,6 @@ docker run -d --name rabbitmq \
     -v ${PWD}/enabled_plugins:/etc/rabbitmq/enabled_plugins \
     -v ${PWD}/rabbitmq_delayed_message_exchange-3.11.1.ez:/opt/rabbitmq/plugins/rabbitmq_delayed_message_exchange-3.11.1.ez \
     ${RABBITMQ_IMAGE}:${RABBITMQ_IMAGE_TAG}
+
+
+wait_for_message rabbitmq "Server startup complete"

--- a/bin/start_rabbitmq.sh
+++ b/bin/start_rabbitmq.sh
@@ -2,8 +2,8 @@
 
 LOCAL_SCRIPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-RABBITMQ_IMAGE_TAG=${RABBITMQ_IMAGE_TAG:-3.11.0-rc.2.29.geee5757.dirty}
-RABBITMQ_IMAGE=${RABBITMQ_IMAGE:-pivotalrabbitmq/rabbitmq}
+RABBITMQ_IMAGE_TAG=${RABBITMQ_IMAGE_TAG:-3.11.3}
+RABBITMQ_IMAGE=${RABBITMQ_IMAGE:-rabbitmq}
 
 wait_for_message() {
   while ! docker logs $1 | grep -q "$2";

--- a/src/main/java/com/rabbitmq/jms/client/DelayedMessageService.java
+++ b/src/main/java/com/rabbitmq/jms/client/DelayedMessageService.java
@@ -1,0 +1,72 @@
+package com.rabbitmq.jms.client;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.jms.admin.RMQDestination;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
+
+class DelayedMessageService {
+    static final String X_DELAYED_JMS_EXCHANGE = "x.delayed.jms.message";
+    static final String X_DELAY_HEADER = "x-delay";
+    static final String X_DELAYED_JMS_EXCHANGE_HEADER = "delayed-exchange";
+
+    /** Cache of exchanges which have been bound to the delayed exchange */
+    private Map<String, Boolean> delayedDestinations;
+    private volatile boolean delayedExchangeDeclared;
+    private Semaphore declaring = new Semaphore(1);
+
+    public DelayedMessageService() {
+        this.delayedDestinations = new ConcurrentHashMap<>();
+    }
+    public void close() {
+        delayedDestinations.clear();
+    }
+
+    public String delayMessage(Channel channel, RMQDestination destination, Map<String, Object> messageHeaders, long deliveryDelayMs) {
+        if (deliveryDelayMs <= 0L) return destination.getAmqpExchangeName();
+
+        declareDelayedExchange(channel);
+        delayedDestinations.computeIfAbsent(destination.getAmqpExchangeName(), destination1 -> {
+            bindDestinationToDelayedExchange(channel, destination);
+            return true;
+        });
+        messageHeaders.put(X_DELAY_HEADER, deliveryDelayMs);
+        messageHeaders.put(X_DELAYED_JMS_EXCHANGE_HEADER, destination.getAmqpExchangeName());
+        return X_DELAYED_JMS_EXCHANGE;
+    }
+    private void declareDelayedExchange(Channel channel) {
+        if (delayedExchangeDeclared) {
+            return;
+        }
+
+        try {
+            declaring.acquire();
+            if (delayedExchangeDeclared) return;
+
+            Map<String, Object> args = new HashMap<>();
+            args.put("x-delayed-type", "headers");
+            channel.exchangeDeclare(X_DELAYED_JMS_EXCHANGE, "x-delayed-message", true,
+                    false, // autoDelete
+                    false, // internal
+                    args); // object properties
+            delayedExchangeDeclared = true;
+        } catch (Exception x) {
+            throw new RuntimeException(x);
+        } finally {
+            declaring.release();
+        }
+    }
+    private void bindDestinationToDelayedExchange(Channel channel, RMQDestination destination) {
+        HashMap<String, Object> map = new HashMap<>();
+        map.put(X_DELAYED_JMS_EXCHANGE_HEADER, destination.getAmqpExchangeName());
+        try {
+            channel.exchangeBind(destination.getAmqpExchangeName(), X_DELAYED_JMS_EXCHANGE, "", map);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/rabbitmq/jms/client/DelayedMessageService.java
+++ b/src/main/java/com/rabbitmq/jms/client/DelayedMessageService.java
@@ -10,7 +10,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
 
 class DelayedMessageService {
-    static final String X_DELAYED_JMS_EXCHANGE = "x.delayed.jms.message";
+    static final String X_DELAYED_JMS_EXCHANGE = "x-delayed-jms-message";
     static final String X_DELAY_HEADER = "x-delay";
     static final String X_DELAYED_JMS_EXCHANGE_HEADER = "delayed-exchange";
 

--- a/src/main/java/com/rabbitmq/jms/client/DelayedMessageService.java
+++ b/src/main/java/com/rabbitmq/jms/client/DelayedMessageService.java
@@ -15,18 +15,18 @@ class DelayedMessageService {
     static final String X_DELAYED_JMS_EXCHANGE_HEADER = "delayed-exchange";
 
     /** Cache of exchanges which have been bound to the delayed exchange */
-    private Map<String, Boolean> delayedDestinations;
+    private final Map<String, Boolean> delayedDestinations;
     private volatile boolean delayedExchangeDeclared;
     private Semaphore declaring = new Semaphore(1);
 
     public DelayedMessageService() {
         this.delayedDestinations = new ConcurrentHashMap<>();
     }
-    public void close() {
+    void close() {
         delayedDestinations.clear();
     }
 
-    public String delayMessage(Channel channel, RMQDestination destination, Map<String, Object> messageHeaders, long deliveryDelayMs) {
+    String delayMessage(Channel channel, RMQDestination destination, Map<String, Object> messageHeaders, long deliveryDelayMs) {
         if (deliveryDelayMs <= 0L) return destination.getAmqpExchangeName();
 
         declareDelayedExchange(channel);
@@ -55,7 +55,7 @@ class DelayedMessageService {
                     args); // object properties
             delayedExchangeDeclared = true;
         } catch (Exception x) {
-            throw new RuntimeException(x);
+            throw new RuntimeException("Failed to declare exchange " + X_DELAYED_JMS_EXCHANGE, x);
         } finally {
             declaring.release();
         }

--- a/src/main/java/com/rabbitmq/jms/client/DelayedMessageService.java
+++ b/src/main/java/com/rabbitmq/jms/client/DelayedMessageService.java
@@ -1,8 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2022 VMware, Inc. or its affiliates. All rights reserved.
+
 package com.rabbitmq.jms.client;
 
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.jms.admin.RMQDestination;
 
+import jakarta.jms.JMSRuntimeException;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -45,7 +52,9 @@ class DelayedMessageService {
 
         try {
             declaring.acquire();
-            if (delayedExchangeDeclared) return;
+            if (delayedExchangeDeclared) {
+                return;
+            }
 
             Map<String, Object> args = new HashMap<>();
             args.put("x-delayed-type", "headers");
@@ -55,7 +64,8 @@ class DelayedMessageService {
                     args); // object properties
             delayedExchangeDeclared = true;
         } catch (Exception x) {
-            throw new RuntimeException("Failed to declare exchange " + X_DELAYED_JMS_EXCHANGE, x);
+            throw new JMSRuntimeException("Failed to declare exchange " + X_DELAYED_JMS_EXCHANGE,
+                "", x);
         } finally {
             declaring.release();
         }

--- a/src/main/java/com/rabbitmq/jms/client/RMQConnection.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQConnection.java
@@ -152,6 +152,8 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
 
     private final boolean keepTextMessageType;
 
+    private final DelayedMessageService delayedMessageService;
+
     /**
      * Creates an RMQConnection object.
      * @param connectionParams parameters for this connection
@@ -178,6 +180,7 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
         this.trustedPackages = connectionParams.getTrustedPackages();
         this.requeueOnTimeout = connectionParams.willRequeueOnTimeout();
         this.keepTextMessageType = connectionParams.isKeepTextMessageType();
+        this.delayedMessageService = new DelayedMessageService();
     }
 
     /**
@@ -233,6 +236,7 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
             .setTrustedPackages(this.trustedPackages)
             .setRequeueOnTimeout(this.requeueOnTimeout)
             .setKeepTextMessageType(this.keepTextMessageType)
+            .setDelayedMessageService(this.delayedMessageService)
         );
         this.sessions.add(session);
         return session;
@@ -369,6 +373,7 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
         this.exceptionListener.set(null);
 
         closeAllSessions();
+        this.delayedMessageService.close();
 
         try {
             this.rabbitConnection.close();

--- a/src/main/java/com/rabbitmq/jms/client/RMQMessage.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQMessage.java
@@ -1464,15 +1464,18 @@ public abstract class RMQMessage implements Message, Cloneable {
     }
 
     @Override
-    public long getJMSDeliveryTime() {
-        // TODO JMS 2.0
-        throw new UnsupportedOperationException();
+    public long getJMSDeliveryTime() throws JMSException {
+        Object deliveryTimeMs = this.getObjectProperty(JMS_MESSAGE_DELIVERY_TIME);
+        if (deliveryTimeMs == null) {
+            return 0L;
+        } else {
+            return Utils.convertToLong(deliveryTimeMs);
+        }
     }
 
     @Override
-    public void setJMSDeliveryTime(long deliveryTime) {
-        // TODO JMS 2.0
-        throw new UnsupportedOperationException();
+    public void setJMSDeliveryTime(long deliveryTime) throws JMSException {
+        this.setObjectProperty(JMS_MESSAGE_DELIVERY_TIME, deliveryTime);
     }
 
     @Override

--- a/src/main/java/com/rabbitmq/jms/client/RMQMessage.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQMessage.java
@@ -119,7 +119,7 @@ public abstract class RMQMessage implements Message, Cloneable {
     static final String JMS_MESSAGE_DELIVERY_MODE = PREFIX + "jms.message.delivery.mode";
     static final String JMS_MESSAGE_EXPIRATION = PREFIX + "jms.message.expiration";
     static final String JMS_MESSAGE_PRIORITY = PREFIX + "jms.message.priority";
-
+    static final String JMS_MESSAGE_DELIVERY_TIME = PREFIX + "jms.message.delivery.type";
     /**
      * JMS Defined Properties
      */

--- a/src/main/java/com/rabbitmq/jms/client/RMQMessageProducer.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQMessageProducer.java
@@ -614,7 +614,7 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
     }
 
     @Override
-    public void setDeliveryDelay(long deliveryDelay) throws JMSException {
+    public void setDeliveryDelay(long deliveryDelay) {
         this.deliveryDelay = deliveryDelay;
     }
 

--- a/src/main/java/com/rabbitmq/jms/client/RMQMessageProducer.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQMessageProducer.java
@@ -350,7 +350,7 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
     private long getDeliveryDelayAndSetJMSDeliveryTimeIfNeeded(RMQMessage rmqMessage, DeliveryTimeSource deliveryTimeSource) throws JMSException {
         long deliveryDelay = 0L;
         long currentTime = System.currentTimeMillis();
-        if (DeliveryTimeSource.message.equals(deliveryTimeSource) || getDeliveryDelay() <= 0L) {
+        if (DeliveryTimeSource.MESSAGE.equals(deliveryTimeSource) || getDeliveryDelay() <= 0L) {
             deliveryDelay = rmqMessage.getJMSDeliveryTime() - currentTime;
         }else if (getDeliveryDelay() > 0L) {
             deliveryDelay = getDeliveryDelay();
@@ -550,8 +550,8 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
     }
 
     private enum DeliveryTimeSource {
-        message, /** the message carries the delivery time */
-        producer /** the producer is configured with a delivery delay */
+        MESSAGE, /** the message carries the delivery time */
+        PRODUCER /** the producer is configured with a delivery delay */
     }
 
     /**
@@ -565,14 +565,14 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
             throws JMSException {
             internalSend((RMQDestination) destination, message, completionListener,
                 getDeliveryMode(), getPriority(), getTimeToLive(), MessageExpirationType.TTL,
-                    DeliveryTimeSource.producer);
+                    DeliveryTimeSource.PRODUCER);
         }
 
         @Override
         public void send(Destination destination, Message message, CompletionListener completionListener,
             int deliveryMode, int priority, long timeToLive) throws JMSException {
             internalSend((RMQDestination) destination, message, completionListener, deliveryMode, priority,
-                    timeToLive, MessageExpirationType.TTL, DeliveryTimeSource.producer);
+                    timeToLive, MessageExpirationType.TTL, DeliveryTimeSource.PRODUCER);
         }
 
     }
@@ -591,14 +591,14 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
                 message.propertyExists(JMS_MESSAGE_PRIORITY) ? message.getJMSPriority() : getPriority(),
                 message.propertyExists(JMS_MESSAGE_EXPIRATION) ? message.getJMSExpiration() : getTimeToLive(),
                 message.propertyExists(JMS_MESSAGE_EXPIRATION) ? MessageExpirationType.EXPIRATION : MessageExpirationType.TTL,
-                message.propertyExists(JMS_MESSAGE_DELIVERY_TIME) ? DeliveryTimeSource.message : DeliveryTimeSource.producer);
+                message.propertyExists(JMS_MESSAGE_DELIVERY_TIME) ? DeliveryTimeSource.MESSAGE : DeliveryTimeSource.PRODUCER);
         }
 
         @Override
         public void send(Destination destination, Message message, CompletionListener completionListener,
             int deliveryMode, int priority, long timeToLive) throws JMSException {
             internalSend((RMQDestination) destination, message, completionListener,
-                deliveryMode, priority, timeToLive, MessageExpirationType.TTL, DeliveryTimeSource.message);
+                deliveryMode, priority, timeToLive, MessageExpirationType.TTL, DeliveryTimeSource.MESSAGE);
         }
 
     }

--- a/src/main/java/com/rabbitmq/jms/client/RMQMessageProducer.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQMessageProducer.java
@@ -350,16 +350,11 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
     private long getDeliveryDelayAndSetJMSDeliveryTimeIfNeeded(RMQMessage rmqMessage, DeliveryTimeSource deliveryTimeSource) throws JMSException {
         long deliveryDelay = 0L;
         long currentTime = System.currentTimeMillis();
-        switch (deliveryTimeSource) {
-            case producer:
-                if (getDeliveryDelay() > 0L) {
-                    deliveryDelay = getDeliveryDelay();
-                    rmqMessage.setJMSDeliveryTime(currentTime + getDeliveryDelay());
-                }
-                break;
-            case message:
-                deliveryDelay = rmqMessage.getJMSDeliveryTime() - currentTime;
-                break;
+        if (DeliveryTimeSource.message.equals(deliveryTimeSource) || getDeliveryDelay() <= 0L) {
+            deliveryDelay = rmqMessage.getJMSDeliveryTime() - currentTime;
+        }else if (getDeliveryDelay() > 0L) {
+            deliveryDelay = getDeliveryDelay();
+            rmqMessage.setJMSDeliveryTime(currentTime + getDeliveryDelay());
         }
         return deliveryDelay;
     }

--- a/src/main/java/com/rabbitmq/jms/client/RMQMessageProducer.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQMessageProducer.java
@@ -29,9 +29,7 @@ import jakarta.jms.TopicPublisher;
 import java.io.IOException;
 import java.util.function.BiFunction;
 
-import static com.rabbitmq.jms.client.RMQMessage.JMS_MESSAGE_DELIVERY_MODE;
-import static com.rabbitmq.jms.client.RMQMessage.JMS_MESSAGE_EXPIRATION;
-import static com.rabbitmq.jms.client.RMQMessage.JMS_MESSAGE_PRIORITY;
+import static com.rabbitmq.jms.client.RMQMessage.*;
 
 /**
  *
@@ -87,6 +85,8 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
      * The default TTL value is 0 (zero), meaning indefinite (no time-out).
      */
     private long ttl = Message.DEFAULT_TIME_TO_LIVE;
+
+    private long deliveryDelay = Message.DEFAULT_DELIVERY_DELAY;
 
     private final SendingStrategy sendingStrategy;
 
@@ -301,8 +301,10 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
 
     private void internalSend(RMQDestination destination, Message message, CompletionListener completionListener,
                               int deliveryMode, int priority, long timeToLiveOrExpiration,
-                              MessageExpirationType messageExpirationType) throws JMSException {
-        logger.trace("send/publish message({}) to destination({}) with properties deliveryMode({}), priority({}), timeToLive({})", message, destination, deliveryMode, priority, timeToLiveOrExpiration);
+                              MessageExpirationType messageExpirationType,
+                              DeliveryTimeSource deliveryTimeSource) throws JMSException {
+        logger.trace("send/publish message({}) to destination({}) with properties deliveryMode({}), priority({}), timeToLive({}), deliveryTimeSource({})",
+                message, destination, deliveryMode, priority, timeToLiveOrExpiration, deliveryTimeSource);
 
         this.sendingContextConsumer.accept(new SendingContext(destination, message));
 
@@ -334,20 +336,31 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
         rmqMessage.setJMSDestination(destination);
         rmqMessage.setJMSTimestamp(currentTime);
         rmqMessage.generateInternalID();
-
+        long deliveryDelay = 0L;
+        switch (deliveryTimeSource) {
+            case producer:
+                if (getDeliveryDelay() > 0L) {
+                    deliveryDelay = getDeliveryDelay();
+                    rmqMessage.setJMSDeliveryTime(currentTime + getDeliveryDelay());
+                }
+                break;
+            case message:
+                deliveryDelay = message.getJMSDeliveryTime() - currentTime;
+                break;
+        }
         /* Now send it */
         if (destination.isAmqp()) {
             sendAMQPMessage(destination, rmqMessage, message, completionListener,
-                deliveryMode, priority, ttl);
+                deliveryMode, priority, ttl, deliveryDelay);
         } else {
             sendJMSMessage(destination, rmqMessage, message, completionListener,
-                deliveryMode, priority, ttl);
+                deliveryMode, priority, ttl, deliveryDelay);
         }
     }
 
     private void sendAMQPMessage(RMQDestination destination, RMQMessage msg, Message originalMessage,
                                  CompletionListener completionListener, int deliveryMode,
-                                 int priority, long timeToLive) throws JMSException {
+                                 int priority, long timeToLive, long deliveryDelay) throws JMSException {
         if (!destination.amqpWritable()) {
             this.logger.error("Cannot write to AMQP destination {}", destination);
             throw new RMQJMSException("Cannot write to AMQP destination", new UnsupportedOperationException("MessageProducer.send to undefined AMQP resource"));
@@ -365,6 +378,7 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
                     messageHeaders.put(RMQMessage.JMS_TYPE_HEADER,
                                        RMQMessage.TEXT_MESSAGE_HEADER_VALUE);
                 }
+                String targetAmqpExchangeName = session.delayMessage(destination, messageHeaders, deliveryDelay);
                 bob.headers(messageHeaders);
 
                 maybeSetReplyToPropertyToDirectReplyTo(bob, msg);
@@ -373,9 +387,8 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
 
                 byte[] data = msg.toAmqpByteArray();
 
-                this.beforePublishingCallback.beforePublishing(originalMessage, completionListener,
-                            this.session.getChannel());
-                this.session.getChannel().basicPublish(destination.getAmqpExchangeName(), destination.getAmqpRoutingKey(), bob.build(), data);
+                this.beforePublishingCallback.beforePublishing(originalMessage, completionListener, this.session.getChannel());
+                this.session.getChannel().basicPublish(targetAmqpExchangeName, destination.getAmqpRoutingKey(), bob.build(), data);
             } catch (IOException x) {
                 throw new RMQJMSException(x);
             }
@@ -388,7 +401,7 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
     // protected for testing
     protected void sendJMSMessage(RMQDestination destination, RMQMessage msg, Message originalMessage,
                                   CompletionListener completionListener,
-                                  int deliveryMode, int priority, long timeToLive) throws JMSException {
+                                  int deliveryMode, int priority, long timeToLive, long deliveryDelay) throws JMSException {
         this.session.declareDestinationIfNecessary(destination);
         try {
             AMQP.BasicProperties.Builder bob = new AMQP.BasicProperties.Builder();
@@ -396,7 +409,9 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
             bob.deliveryMode(RMQMessage.rmqDeliveryMode(deliveryMode));
             bob.priority(priority);
             bob.expiration(rmqExpiration(timeToLive));
-            bob.headers(msg.toHeaders());
+            Map<String, Object> headers = msg.toHeaders();
+            String targetAmqpExchangeName = session.delayMessage(destination, headers, deliveryDelay);
+            bob.headers(headers);
 
             maybeSetReplyToPropertyToDirectReplyTo(bob, msg);
 
@@ -404,7 +419,7 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
 
             this.beforePublishingCallback.beforePublishing(originalMessage, completionListener,
                 this.session.getChannel());
-            this.session.getChannel().basicPublish(destination.getAmqpExchangeName(), destination.getAmqpRoutingKey(), bob.build(), data);
+            this.session.getChannel().basicPublish(targetAmqpExchangeName, destination.getAmqpRoutingKey(), bob.build(), data);
         } catch (IOException x) {
             throw new RMQJMSException(x);
         }
@@ -533,6 +548,11 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
 
     }
 
+    private enum DeliveryTimeSource {
+        message, /** the message carries the delivery time */
+        producer /** the producer is configured with a delivery delay */
+    }
+
     /**
      * This implementation ignores message properties (delivery mode, priority, and expiration)
      * in favor of the message producer's properties.
@@ -543,13 +563,15 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
         public void send(Destination destination, Message message, CompletionListener completionListener)
             throws JMSException {
             internalSend((RMQDestination) destination, message, completionListener,
-                getDeliveryMode(), getPriority(), getTimeToLive(), MessageExpirationType.TTL);
+                getDeliveryMode(), getPriority(), getTimeToLive(), MessageExpirationType.TTL,
+                    DeliveryTimeSource.producer);
         }
 
         @Override
         public void send(Destination destination, Message message, CompletionListener completionListener,
             int deliveryMode, int priority, long timeToLive) throws JMSException {
-            internalSend((RMQDestination) destination, message, completionListener, deliveryMode, priority, timeToLive, MessageExpirationType.TTL);
+            internalSend((RMQDestination) destination, message, completionListener, deliveryMode, priority,
+                    timeToLive, MessageExpirationType.TTL, DeliveryTimeSource.producer);
         }
 
     }
@@ -567,14 +589,15 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
                 message.propertyExists(JMS_MESSAGE_DELIVERY_MODE) ? message.getJMSDeliveryMode() : getDeliveryMode(),
                 message.propertyExists(JMS_MESSAGE_PRIORITY) ? message.getJMSPriority() : getPriority(),
                 message.propertyExists(JMS_MESSAGE_EXPIRATION) ? message.getJMSExpiration() : getTimeToLive(),
-                message.propertyExists(JMS_MESSAGE_EXPIRATION) ? MessageExpirationType.EXPIRATION : MessageExpirationType.TTL);
+                message.propertyExists(JMS_MESSAGE_EXPIRATION) ? MessageExpirationType.EXPIRATION : MessageExpirationType.TTL,
+                message.propertyExists(JMS_MESSAGE_DELIVERY_TIME) ? DeliveryTimeSource.message : DeliveryTimeSource.producer);
         }
 
         @Override
         public void send(Destination destination, Message message, CompletionListener completionListener,
             int deliveryMode, int priority, long timeToLive) throws JMSException {
             internalSend((RMQDestination) destination, message, completionListener,
-                deliveryMode, priority, timeToLive, MessageExpirationType.TTL);
+                deliveryMode, priority, timeToLive, MessageExpirationType.TTL, DeliveryTimeSource.message);
         }
 
     }
@@ -591,14 +614,12 @@ public class RMQMessageProducer implements MessageProducer, QueueSender, TopicPu
 
     @Override
     public void setDeliveryDelay(long deliveryDelay) throws JMSException {
-        // TODO JMS 2.0
-        throw new UnsupportedOperationException();
+        this.deliveryDelay = deliveryDelay;
     }
 
     @Override
     public long getDeliveryDelay() {
-        // TODO JMS 2.0
-        throw new UnsupportedOperationException();
+        return deliveryDelay;
     }
 
     @Override

--- a/src/main/java/com/rabbitmq/jms/client/RMQSession.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQSession.java
@@ -19,8 +19,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
 
@@ -65,6 +64,7 @@ import com.rabbitmq.jms.client.message.RMQStreamMessage;
 import com.rabbitmq.jms.client.message.RMQTextMessage;
 import com.rabbitmq.jms.util.RMQJMSException;
 import com.rabbitmq.jms.util.Util;
+
 /**
  * RabbitMQ implementation of JMS {@link Session}
  */
@@ -710,6 +710,85 @@ public class RMQSession implements Session, QueueSession, TopicSession {
             }
         }
     }
+    private DelayedDestinationService delayedMessageService = new DelayedDestinationService();
+
+    static final String X_DELAYED_JMS_EXCHANGE = "x.delayed.jms.message";
+    static final String X_DELAY_HEADER = "x-delay";
+    static final String X_DELAYED_JMS_EXCHANGE_HEADER = "destination";
+
+    /**
+     * Prepare a message for delayed delivery. If deliveryDelayMs > 0, it declares the exchange X_DELAYED_JMS_EXCHANGE
+     * and binds to the target destination. It returns X_DELAYED_JMS_EXCHANGE and adds the following headers to the
+     * headers map:
+     * - x-delay : it has deliveryDelayMs
+     * - destination : it has the name of the target exchange
+     *
+     * If deliveryDelayMs < 1, it returns the name of exchange associated to the target destination.
+     *
+     * @param destination
+     * @param messageHeaders
+     * @param deliveryDelayMs
+     * @return
+     */
+    String delayMessage(RMQDestination destination, Map<String, Object> messageHeaders, long deliveryDelayMs) {
+        return delayedMessageService.delayMessage(destination, messageHeaders, deliveryDelayMs);
+    }
+
+    class DelayedDestinationService {
+        Map<RMQDestination, Boolean> delayedDestinations;
+        volatile boolean delayedExchangeDeclared;
+        Semaphore declaring = new Semaphore(1);
+
+        public DelayedDestinationService() {
+            this.delayedDestinations = new ConcurrentHashMap<>();
+        }
+
+        public String delayMessage(RMQDestination destination, Map<String, Object> messageHeaders, long deliveryDelayMs) {
+            if (deliveryDelayMs <= 0L) return destination.getAmqpExchangeName();
+
+            declareDelayedExchange();
+            delayedDestinations.computeIfAbsent(destination, destination1 -> {
+                bindDestinationToDelayedExchange(destination1);
+                return true;
+            });
+            messageHeaders.put(X_DELAY_HEADER, deliveryDelayMs);
+            messageHeaders.put(X_DELAYED_JMS_EXCHANGE_HEADER, destination.getAmqpExchangeName());
+            return X_DELAYED_JMS_EXCHANGE;
+        }
+        private void declareDelayedExchange() {
+            if (delayedExchangeDeclared) {
+                return;
+            }
+
+            try {
+                declaring.acquire();
+                if (delayedExchangeDeclared) return;
+
+                logger.trace("declare RabbitMQ delayed exchange");
+                Map<String, Object> args = new HashMap<>();
+                args.put("x-delayed-type", "headers");
+                channel.exchangeDeclare(X_DELAYED_JMS_EXCHANGE, "x-delayed-message", true,
+                        false, // autoDelete
+                        false, // internal
+                        args); // object properties
+                delayedExchangeDeclared = true;
+            } catch (Exception x) {
+                throw new RuntimeException(x);
+            } finally {
+                declaring.release();
+            }
+        }
+        private void bindDestinationToDelayedExchange(RMQDestination destination) {
+            HashMap<String, Object> map = new HashMap<>();
+            map.put("destination", destination.getAmqpExchangeName());
+            try {
+                channel.exchangeBind(destination.getAmqpExchangeName(), X_DELAYED_JMS_EXCHANGE, "", map);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
 
     /**
      * {@inheritDoc}
@@ -801,6 +880,8 @@ public class RMQSession implements Session, QueueSession, TopicSession {
         return this.nonDurableTopicSelectorExchange;
     }
 
+
+
     /**
      * {@inheritDoc}
      * @throws UnsupportedOperationException - method not implemented until we support selectors
@@ -857,6 +938,7 @@ public class RMQSession implements Session, QueueSession, TopicSession {
         declareRMQQueue(dest, null, false, true);
         return dest;
     }
+
 
     /**
      * Invokes {@link Channel#queueDeclare(String, boolean, boolean, boolean, java.util.Map)} to define a queue on the RabbitMQ broker

--- a/src/main/java/com/rabbitmq/jms/client/SessionParams.java
+++ b/src/main/java/com/rabbitmq/jms/client/SessionParams.java
@@ -105,6 +105,8 @@ public class SessionParams {
 
     private List<String> trustedPackages = WhiteListObjectInputStream.DEFAULT_TRUSTED_PACKAGES;
 
+    private DelayedMessageService delayedMessageService;
+
     public RMQConnection getConnection() {
         return connection;
     }
@@ -240,4 +242,12 @@ public class SessionParams {
         return requeueOnTimeout;
     }
 
+    public DelayedMessageService getDelayedMessageService() {
+        return delayedMessageService;
+    }
+
+    public SessionParams setDelayedMessageService(DelayedMessageService delayedMessageService) {
+        this.delayedMessageService = delayedMessageService;
+        return this;
+    }
 }

--- a/src/test/java/com/rabbitmq/TestUtils.java
+++ b/src/test/java/com/rabbitmq/TestUtils.java
@@ -20,7 +20,6 @@ import java.util.concurrent.Callable;
 import jakarta.jms.CompletionListener;
 import jakarta.jms.JMSException;
 import jakarta.jms.Message;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
@@ -101,7 +100,7 @@ public class TestUtils {
       }
     }
   }
-  private static boolean isPluginEnabled(String plugin) {
+  private static boolean isPluginActivated(String plugin) {
     if (Shell.rabbitmqctlCommand() == null) {
       throw new IllegalStateException(
               "rabbitmqctl.bin system property not set, cannot check if TLS is enabled");
@@ -150,39 +149,41 @@ public class TestUtils {
   @Target({ElementType.TYPE, ElementType.METHOD})
   @Retention(RetentionPolicy.RUNTIME)
   @Documented
-  @ExtendWith(DisabledIfTlsNotEnabledCondition.class)
-  public @interface DisabledIfTlsNotEnabled {
+  @ExtendWith(SkipIfTlsNotActivatedCondition.class)
+  public @interface SkipIfTlsNotActivated {
 
   }
 
   @Target({ElementType.TYPE, ElementType.METHOD})
   @Retention(RetentionPolicy.RUNTIME)
   @Documented
-  @ExtendWith(DisabledIfDelayedMessageExchangePluginNotEnabledCondition.class)
-  public @interface DisabledIfDelayedMessageExchangePluginNotEnabled {
+  @ExtendWith(SkipIfDelayedMessageExchangePluginNotActivatedCondition.class)
+  public @interface SkipIfDelayedMessageExchangePluginNotActivated {
 
   }
 
-  private static class DisabledIfTlsNotEnabledCondition implements ExecutionCondition {
+  private static class SkipIfTlsNotActivatedCondition implements ExecutionCondition {
 
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
       if (tlsAvailable()) {
-        return ConditionEvaluationResult.enabled("TLS is enabled");
+        return ConditionEvaluationResult.enabled("TLS is available");
       } else {
-        return ConditionEvaluationResult.disabled("TLS is disabled");
+        return ConditionEvaluationResult.disabled("TLS is not available");
       }
     }
   }
-  private static class DisabledIfDelayedMessageExchangePluginNotEnabledCondition implements ExecutionCondition {
+  private static class SkipIfDelayedMessageExchangePluginNotActivatedCondition implements ExecutionCondition {
 
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+      String plugin = "rabbitmq_delayed_message_exchange";
       try {
-        isPluginEnabled("rabbitmq_delayed_message_exchange");
-        return ConditionEvaluationResult.enabled("rabbitmq_delayed_message_exchange is enabled");
+        boolean activated = isPluginActivated(plugin);
+        return activated ? ConditionEvaluationResult.enabled(plugin + " plugin is activated") :
+            ConditionEvaluationResult.disabled(plugin + " plugin is not activated");
       } catch(Exception e) {
-        return ConditionEvaluationResult.disabled("rabbitmq_delayed_message_exchange is disabled");
+        return ConditionEvaluationResult.disabled(plugin + " plugin is not activated");
       }
     }
   }

--- a/src/test/java/com/rabbitmq/TestUtils.java
+++ b/src/test/java/com/rabbitmq/TestUtils.java
@@ -20,6 +20,7 @@ import java.util.concurrent.Callable;
 import jakarta.jms.CompletionListener;
 import jakarta.jms.JMSException;
 import jakarta.jms.Message;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
 import org.junit.jupiter.api.extension.ExecutionCondition;
@@ -140,6 +141,14 @@ public class TestUtils {
 
   }
 
+  @Target({ElementType.TYPE, ElementType.METHOD})
+  @Retention(RetentionPolicy.RUNTIME)
+  @Documented
+  @ExtendWith(DisabledIfDelayedMessageExchangePluginNotEnabledCondition.class)
+  public @interface DisabledIfDelayedMessageExchangePluginNotEnabled {
+
+  }
+
   private static class DisabledIfTlsNotEnabledCondition implements ExecutionCondition {
 
     @Override
@@ -151,4 +160,18 @@ public class TestUtils {
       }
     }
   }
+  private static class DisabledIfDelayedMessageExchangePluginNotEnabledCondition implements ExecutionCondition {
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+      try {
+        Shell.rabbitmqPlugins("is_enabled rabbitmq_delayed_message_exchange");
+        return ConditionEvaluationResult.enabled("rabbitmq_delayed_message_exchange is enabled");
+      } catch(Exception e) {
+        return ConditionEvaluationResult.disabled("rabbitmq_delayed_message_exchange is disabled");
+      }
+    }
+  }
+
+
 }

--- a/src/test/java/com/rabbitmq/TestUtils.java
+++ b/src/test/java/com/rabbitmq/TestUtils.java
@@ -101,6 +101,20 @@ public class TestUtils {
       }
     }
   }
+  private static boolean isPluginEnabled(String plugin) {
+    if (Shell.rabbitmqctlCommand() == null) {
+      throw new IllegalStateException(
+              "rabbitmqctl.bin system property not set, cannot check if TLS is enabled");
+    } else {
+      try {
+        ProcessState process = Shell.rabbitmqctl("status");
+        String output = process.output();
+        return output.contains(plugin);
+      } catch (Exception e) {
+        throw new RuntimeException("Error while detecting if plugin " + plugin + " is enabled: " + e.getMessage());
+      }
+    }
+  }
 
   public static String queueName(TestInfo info) {
     return queueName(info.getTestClass().get(), info.getTestMethod().get());
@@ -165,7 +179,7 @@ public class TestUtils {
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
       try {
-        Shell.rabbitmqPlugins("is_enabled rabbitmq_delayed_message_exchange");
+        isPluginEnabled("rabbitmq_delayed_message_exchange");
         return ConditionEvaluationResult.enabled("rabbitmq_delayed_message_exchange is enabled");
       } catch(Exception e) {
         return ConditionEvaluationResult.disabled("rabbitmq_delayed_message_exchange is disabled");

--- a/src/test/java/com/rabbitmq/integration/tests/DelayedAMQPQueueMessageIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/DelayedAMQPQueueMessageIT.java
@@ -2,10 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2013-2022 VMware, Inc. or its affiliates. All rights reserved.
+// Copyright (c) 2022 VMware, Inc. or its affiliates. All rights reserved.
 package com.rabbitmq.integration.tests;
 
-import com.rabbitmq.TestUtils.DisabledIfDelayedMessageExchangePluginNotEnabled;
+import com.rabbitmq.TestUtils.SkipIfDelayedMessageExchangePluginNotActivated;
 import com.rabbitmq.jms.admin.RMQDestination;
 import jakarta.jms.JMSConsumer;
 import jakarta.jms.JMSContext;
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 /**
  * Integration test
  */
-@DisabledIfDelayedMessageExchangePluginNotEnabled
+@SkipIfDelayedMessageExchangePluginNotActivated
 public class DelayedAMQPQueueMessageIT extends AbstractAmqpITQueue {
 
     String queueName = "DelayedAMQPQueueMessageIT";

--- a/src/test/java/com/rabbitmq/integration/tests/DelayedAMQPQueueMessageIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/DelayedAMQPQueueMessageIT.java
@@ -2,45 +2,38 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2013-2020 VMware, Inc. or its affiliates. All rights reserved.
+// Copyright (c) 2013-2022 VMware, Inc. or its affiliates. All rights reserved.
 package com.rabbitmq.integration.tests;
 
 import com.rabbitmq.TestUtils;
+import com.rabbitmq.TestUtils.DisabledIfDelayedMessageExchangePluginNotEnabled;
 import com.rabbitmq.jms.admin.RMQDestination;
 import com.rabbitmq.jms.util.Shell;
-import jakarta.jms.*;
-import org.junit.jupiter.api.*;
+import jakarta.jms.JMSConsumer;
+import jakarta.jms.JMSContext;
+import jakarta.jms.JMSProducer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.concurrent.CountDownLatch;
-import java.util.stream.IntStream;
 
-import static com.rabbitmq.Assertions.assertThat;
-import static com.rabbitmq.TestUtils.onCompletion;
-import static java.lang.String.valueOf;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Integration test
  */
+@DisabledIfDelayedMessageExchangePluginNotEnabled
 public class DelayedAMQPQueueMessageIT extends AbstractAmqpITQueue {
 
     String queueName = "DelayedAMQPQueueMessageIT";
     RMQDestination destination;
 
     @BeforeEach
-    void init() throws Exception {
+    void init() {
         destination = new RMQDestination(queueName, true, false);
-    }
-
-    @BeforeEach
-    public void beforeMethod() throws IOException {
-        try {
-            Shell.rabbitmqPlugins("is_enabled rabbitmq_delayed_message_exchange");
-        }catch(Exception e) {
-            System.out.println("Skipped DelayedMessageIT. Plugin rabbitmq_delayed_message_exchange is not enabled");
-            Assumptions.assumeTrue(false);
-        }
     }
 
     @AfterEach

--- a/src/test/java/com/rabbitmq/integration/tests/DelayedAMQPQueueMessageIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/DelayedAMQPQueueMessageIT.java
@@ -1,0 +1,70 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2013-2020 VMware, Inc. or its affiliates. All rights reserved.
+package com.rabbitmq.integration.tests;
+
+import com.rabbitmq.TestUtils;
+import com.rabbitmq.jms.admin.RMQDestination;
+import com.rabbitmq.jms.util.Shell;
+import jakarta.jms.*;
+import org.junit.jupiter.api.*;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.IntStream;
+
+import static com.rabbitmq.Assertions.assertThat;
+import static com.rabbitmq.TestUtils.onCompletion;
+import static java.lang.String.valueOf;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration test
+ */
+public class DelayedAMQPQueueMessageIT extends AbstractAmqpITQueue {
+
+    String queueName;
+    RMQDestination destination;
+
+    @BeforeEach
+    void init(TestInfo info) throws Exception {
+        queueName = TestUtils.queueName(info);
+        destination = new RMQDestination(queueName, true, false);
+    }
+
+    @BeforeEach
+    public void beforeMethod() throws IOException {
+        try {
+            Shell.rabbitmqPlugins("is_enabled rabbitmq_delayed_message_exchange");
+        }catch(Exception e) {
+            System.out.println("Skipped DelayedMessageIT. Plugin rabbitmq_delayed_message_exchange is not enabled");
+            Assumptions.assumeTrue(false);
+        }
+    }
+
+    @AfterEach
+    void dispose() throws Exception {
+        this.channel.queueDelete(queueName);
+    }
+
+    @Test
+    void sendMessageToAMQPQueue() {
+
+        try (JMSContext context = this.connFactory.createContext()) {
+            JMSProducer producer = context.createProducer();
+            producer.setDeliveryDelay(4000L);
+            producer.send(destination, "test message");
+        }
+
+        try (JMSContext context = this.connFactory.createContext(JMSContext.AUTO_ACKNOWLEDGE)) {
+            JMSConsumer consumer = context.createConsumer(destination);
+
+            assertNull(consumer.receive(2000L));
+            assertNotNull(consumer.receive(3000L));
+        }
+
+    }
+
+}

--- a/src/test/java/com/rabbitmq/integration/tests/DelayedAMQPQueueMessageIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/DelayedAMQPQueueMessageIT.java
@@ -5,19 +5,14 @@
 // Copyright (c) 2013-2022 VMware, Inc. or its affiliates. All rights reserved.
 package com.rabbitmq.integration.tests;
 
-import com.rabbitmq.TestUtils;
 import com.rabbitmq.TestUtils.DisabledIfDelayedMessageExchangePluginNotEnabled;
 import com.rabbitmq.jms.admin.RMQDestination;
-import com.rabbitmq.jms.util.Shell;
 import jakarta.jms.JMSConsumer;
 import jakarta.jms.JMSContext;
 import jakarta.jms.JMSProducer;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;

--- a/src/test/java/com/rabbitmq/integration/tests/DelayedAMQPQueueMessageIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/DelayedAMQPQueueMessageIT.java
@@ -25,12 +25,11 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class DelayedAMQPQueueMessageIT extends AbstractAmqpITQueue {
 
-    String queueName;
+    String queueName = "DelayedAMQPQueueMessageIT";
     RMQDestination destination;
 
     @BeforeEach
     void init() throws Exception {
-        queueName = "DelayedAMQPQueueMessageIT";
         destination = new RMQDestination(queueName, true, false);
     }
 

--- a/src/test/java/com/rabbitmq/integration/tests/DelayedAMQPQueueMessageIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/DelayedAMQPQueueMessageIT.java
@@ -29,8 +29,8 @@ public class DelayedAMQPQueueMessageIT extends AbstractAmqpITQueue {
     RMQDestination destination;
 
     @BeforeEach
-    void init(TestInfo info) throws Exception {
-        queueName = TestUtils.queueName(info);
+    void init() throws Exception {
+        queueName = "DelayedAMQPQueueMessageIT";
         destination = new RMQDestination(queueName, true, false);
     }
 

--- a/src/test/java/com/rabbitmq/integration/tests/DelayedMessageIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/DelayedMessageIT.java
@@ -1,0 +1,56 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2013-2020 VMware, Inc. or its affiliates. All rights reserved.
+package com.rabbitmq.integration.tests;
+
+import com.rabbitmq.jms.util.Shell;
+import jakarta.jms.*;
+import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static com.rabbitmq.jms.util.Shell.rabbitmqPlugins;
+import static com.rabbitmq.jms.util.Shell.rabbitmqctlCommand;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Integration test
+ */
+public class DelayedMessageIT extends AbstractITQueue {
+
+    private static final String MESSAGE = "Hello " + DelayedMessageIT.class.getName();
+
+    @BeforeEach
+    public void beforeMethod() throws IOException {
+        try {
+            Shell.rabbitmqPlugins("is_enabled rabbitmq_delayed_message_exchange");
+        }catch(Exception e) {
+            System.out.println("Skipped DelayedMessageIT. Plugin rabbitmq_delayed_message_exchange is not enabled");
+            org.junit.Assume.assumeTrue(false);
+        }
+    }
+
+
+    @Test
+    public void testJMSQueue() throws Exception {
+        queueConn.start();
+        QueueSession queueSession = queueConn.createQueueSession(false, Session.DUPS_OK_ACKNOWLEDGE);
+        Queue queue = queueSession.createTemporaryQueue();
+        QueueSender queueSender = queueSession.createSender(queue);
+        queueSender.setDeliveryDelay(1000L);
+        queueSender.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+        TextMessage message = queueSession.createTextMessage(MESSAGE);
+        queueSender.send(message);
+        QueueReceiver queueReceiver = queueSession.createReceiver(queue);
+        message = (TextMessage) queueReceiver.receive(2000L);
+        assertNotNull(message);
+        assertEquals(MESSAGE, message.getText());
+    }
+
+
+}

--- a/src/test/java/com/rabbitmq/integration/tests/DelayedQueueMessageIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/DelayedQueueMessageIT.java
@@ -37,17 +37,19 @@ public class DelayedQueueMessageIT extends AbstractITQueue {
 
 
     @Test
-    public void testJMSTemporaryQueue() throws Exception {
+    public void testSendMessageToJMSTemporaryQueue() throws Exception {
         queueConn.start();
         QueueSession queueSession = queueConn.createQueueSession(false, Session.DUPS_OK_ACKNOWLEDGE);
         Queue queue = queueSession.createTemporaryQueue();
         QueueSender queueSender = queueSession.createSender(queue);
-        queueSender.setDeliveryDelay(1000L);
+        queueSender.setDeliveryDelay(4000L);
         queueSender.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
         TextMessage message = queueSession.createTextMessage(MESSAGE);
         queueSender.send(message);
+
         QueueReceiver queueReceiver = queueSession.createReceiver(queue);
-        TextMessage receivedMessage = (TextMessage) queueReceiver.receive(2000L);
+        assertNull(queueReceiver.receive(2000L));
+        TextMessage receivedMessage = (TextMessage) queueReceiver.receive(3000L);
         assertNotNull(receivedMessage);
         assertTrue(receivedMessage.getJMSDeliveryTime() > 0);
         assertEquals(MESSAGE, receivedMessage.getText());
@@ -65,6 +67,7 @@ public class DelayedQueueMessageIT extends AbstractITQueue {
         TextMessage message = queueSession.createTextMessage(MESSAGE);
         message.setJMSDeliveryTime(System.currentTimeMillis() + 4000L);
         queueSender.send(message);
+        
         QueueReceiver queueReceiver = queueSession.createReceiver(queue);
         assertNull(queueReceiver.receive(2000L));
         TextMessage receivedMessage = (TextMessage)queueReceiver.receive(2000L);

--- a/src/test/java/com/rabbitmq/integration/tests/DelayedQueueMessageIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/DelayedQueueMessageIT.java
@@ -2,39 +2,28 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2013-2020 VMware, Inc. or its affiliates. All rights reserved.
+// Copyright (c) 2013-2022 VMware, Inc. or its affiliates. All rights reserved.
 package com.rabbitmq.integration.tests;
 
+import com.rabbitmq.TestUtils;
+import com.rabbitmq.TestUtils.DisabledIfDelayedMessageExchangePluginNotEnabled;
 import com.rabbitmq.jms.util.Shell;
 import jakarta.jms.*;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Integration test
  */
+@DisabledIfDelayedMessageExchangePluginNotEnabled
 public class DelayedQueueMessageIT extends AbstractITQueue {
 
     private static final String MESSAGE = "Hello " + DelayedQueueMessageIT.class.getName();
 
     private static final String QUEUE_NAME = "delay.queue.";
-
-    @BeforeEach
-    public void beforeMethod() throws IOException {
-        try {
-            Shell.rabbitmqPlugins("is_enabled rabbitmq_delayed_message_exchange");
-        }catch(Exception e) {
-            e.printStackTrace();
-            System.out.println("Skipped DelayedMessageIT. Plugin rabbitmq_delayed_message_exchange is not enabled");
-            Assumptions.assumeTrue(false);
-        }
-    }
-
 
     @Test
     public void testSendMessageToJMSTemporaryQueue() throws Exception {

--- a/src/test/java/com/rabbitmq/integration/tests/DelayedQueueMessageIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/DelayedQueueMessageIT.java
@@ -5,12 +5,8 @@
 // Copyright (c) 2013-2022 VMware, Inc. or its affiliates. All rights reserved.
 package com.rabbitmq.integration.tests;
 
-import com.rabbitmq.TestUtils;
 import com.rabbitmq.TestUtils.DisabledIfDelayedMessageExchangePluginNotEnabled;
-import com.rabbitmq.jms.util.Shell;
 import jakarta.jms.*;
-import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/rabbitmq/integration/tests/DelayedQueueMessageIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/DelayedQueueMessageIT.java
@@ -2,10 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2013-2022 VMware, Inc. or its affiliates. All rights reserved.
+// Copyright (c) 2022 VMware, Inc. or its affiliates. All rights reserved.
 package com.rabbitmq.integration.tests;
 
-import com.rabbitmq.TestUtils.DisabledIfDelayedMessageExchangePluginNotEnabled;
+import com.rabbitmq.TestUtils.SkipIfDelayedMessageExchangePluginNotActivated;
 import jakarta.jms.*;
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Integration test
  */
-@DisabledIfDelayedMessageExchangePluginNotEnabled
+@SkipIfDelayedMessageExchangePluginNotActivated
 public class DelayedQueueMessageIT extends AbstractITQueue {
 
     private static final String MESSAGE = "Hello " + DelayedQueueMessageIT.class.getName();

--- a/src/test/java/com/rabbitmq/integration/tests/DelayedQueueMessageIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/DelayedQueueMessageIT.java
@@ -7,23 +7,21 @@ package com.rabbitmq.integration.tests;
 
 import com.rabbitmq.jms.util.Shell;
 import jakarta.jms.*;
-import org.junit.Before;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static com.rabbitmq.jms.util.Shell.rabbitmqPlugins;
-import static com.rabbitmq.jms.util.Shell.rabbitmqctlCommand;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Integration test
  */
-public class DelayedMessageIT extends AbstractITQueue {
+public class DelayedQueueMessageIT extends AbstractITQueue {
 
-    private static final String MESSAGE = "Hello " + DelayedMessageIT.class.getName();
+    private static final String MESSAGE = "Hello " + DelayedQueueMessageIT.class.getName();
 
     @BeforeEach
     public void beforeMethod() throws IOException {
@@ -31,7 +29,7 @@ public class DelayedMessageIT extends AbstractITQueue {
             Shell.rabbitmqPlugins("is_enabled rabbitmq_delayed_message_exchange");
         }catch(Exception e) {
             System.out.println("Skipped DelayedMessageIT. Plugin rabbitmq_delayed_message_exchange is not enabled");
-            org.junit.Assume.assumeTrue(false);
+            Assumptions.assumeTrue(false);
         }
     }
 

--- a/src/test/java/com/rabbitmq/integration/tests/DelayedQueueMessageIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/DelayedQueueMessageIT.java
@@ -22,7 +22,7 @@ public class DelayedQueueMessageIT extends AbstractITQueue {
 
     private static final String MESSAGE = "Hello " + DelayedQueueMessageIT.class.getName();
 
-    private static final String QUEUE_NAME = "delay.queue." + DelayedQueueMessageIT.class.getCanonicalName();
+    private static final String QUEUE_NAME = "delay.queue.";
 
     @BeforeEach
     public void beforeMethod() throws IOException {
@@ -60,17 +60,17 @@ public class DelayedQueueMessageIT extends AbstractITQueue {
     public void testSendDelayedMessageToJMSQueue() throws Exception {
         queueConn.start();
         QueueSession queueSession = queueConn.createQueueSession(false, Session.DUPS_OK_ACKNOWLEDGE);
-        Queue queue = queueSession.createQueue(QUEUE_NAME);
+        Queue queue = queueSession.createQueue(QUEUE_NAME + System.currentTimeMillis());
         QueueSender queueSender = queueSession.createSender(queue);
 
         queueSender.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
         TextMessage message = queueSession.createTextMessage(MESSAGE);
         message.setJMSDeliveryTime(System.currentTimeMillis() + 4000L);
         queueSender.send(message);
-        
+
         QueueReceiver queueReceiver = queueSession.createReceiver(queue);
         assertNull(queueReceiver.receive(2000L));
-        TextMessage receivedMessage = (TextMessage)queueReceiver.receive(2000L);
+        TextMessage receivedMessage = (TextMessage)queueReceiver.receive();
         assertNotNull(receivedMessage);
         assertEquals(message.getJMSDeliveryTime(), receivedMessage.getJMSDeliveryTime());
         assertEquals(MESSAGE, receivedMessage.getText());
@@ -80,7 +80,7 @@ public class DelayedQueueMessageIT extends AbstractITQueue {
     public void testSendMessageViaDelayedProducerToJMSQueue() throws Exception {
         queueConn.start();
         QueueSession queueSession = queueConn.createQueueSession(false, Session.DUPS_OK_ACKNOWLEDGE);
-        Queue queue = queueSession.createQueue(QUEUE_NAME);
+        Queue queue = queueSession.createQueue(QUEUE_NAME + System.currentTimeMillis());
         QueueSender queueSender = queueSession.createSender(queue);
         queueSender.setDeliveryDelay(4000L);
         queueSender.setDeliveryMode(DeliveryMode.NON_PERSISTENT);

--- a/src/test/java/com/rabbitmq/integration/tests/DelayedTopicMessageIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/DelayedTopicMessageIT.java
@@ -5,12 +5,8 @@
 // Copyright (c) 2013-2022 VMware, Inc. or its affiliates. All rights reserved.
 package com.rabbitmq.integration.tests;
 
-import com.rabbitmq.TestUtils;
 import com.rabbitmq.TestUtils.DisabledIfDelayedMessageExchangePluginNotEnabled;
-import com.rabbitmq.jms.util.Shell;
 import jakarta.jms.*;
-import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/rabbitmq/integration/tests/DelayedTopicMessageIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/DelayedTopicMessageIT.java
@@ -2,40 +2,29 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2013-2020 VMware, Inc. or its affiliates. All rights reserved.
+// Copyright (c) 2013-2022 VMware, Inc. or its affiliates. All rights reserved.
 package com.rabbitmq.integration.tests;
 
+import com.rabbitmq.TestUtils;
+import com.rabbitmq.TestUtils.DisabledIfDelayedMessageExchangePluginNotEnabled;
 import com.rabbitmq.jms.util.Shell;
 import jakarta.jms.*;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Integration test
  */
+@DisabledIfDelayedMessageExchangePluginNotEnabled
 public class DelayedTopicMessageIT extends AbstractITTopic {
 
-    private static final String MESSAGE = "Hello " + DelayedTopicMessageIT.class.getName();
-
     private static final String TOPIC_NAME = "delay.topic." + DelayedTopicMessageIT.class.getCanonicalName();
-    private static final String WILD_TOPIC_NAME = "delay.topic.#";
     private static final String MESSAGE_TEXT_1 = "Hello " + DelayedTopicMessageIT.class.getName();
-    private static final String MESSAGE_TEXT_2 = "Wild hello " + DelayedTopicMessageIT.class.getName();
 
-    @BeforeEach
-    public void beforeMethod() throws IOException {
-        try {
-            Shell.rabbitmqPlugins("is_enabled rabbitmq_delayed_message_exchange");
-        }catch(Exception e) {
-            System.out.println("Skipped DelayedMessageIT. Plugin rabbitmq_delayed_message_exchange is not enabled");
-            Assumptions.assumeTrue(false);
-        }
-    }
+
     @Test
     public void testSendMessageToTopicWithDelayedPublisher() throws Exception {
         topicConn.start();

--- a/src/test/java/com/rabbitmq/integration/tests/DelayedTopicMessageIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/DelayedTopicMessageIT.java
@@ -2,10 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2013-2022 VMware, Inc. or its affiliates. All rights reserved.
+// Copyright (c) 2022 VMware, Inc. or its affiliates. All rights reserved.
 package com.rabbitmq.integration.tests;
 
-import com.rabbitmq.TestUtils.DisabledIfDelayedMessageExchangePluginNotEnabled;
+import com.rabbitmq.TestUtils.SkipIfDelayedMessageExchangePluginNotActivated;
 import jakarta.jms.*;
 import org.junit.jupiter.api.Test;
 
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Integration test
  */
-@DisabledIfDelayedMessageExchangePluginNotEnabled
+@SkipIfDelayedMessageExchangePluginNotActivated
 public class DelayedTopicMessageIT extends AbstractITTopic {
 
     private static final String TOPIC_NAME = "delay.topic." + DelayedTopicMessageIT.class.getCanonicalName();
@@ -28,15 +28,15 @@ public class DelayedTopicMessageIT extends AbstractITTopic {
         Topic topic = topicSession.createTopic(TOPIC_NAME);
         TopicPublisher sender = topicSession.createPublisher(topic);
         sender.setDeliveryDelay(4000L);
-        TopicSubscriber receiver1 = topicSession.createSubscriber(topic);
+        TopicSubscriber receiver = topicSession.createSubscriber(topic);
 
         // TODO probably ensure the topic is empty
         sender.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
         TextMessage message = topicSession.createTextMessage(MESSAGE_TEXT_1);
         sender.send(message);
 
-        assertNull(receiver1.receive(2000L));
-        TextMessage receivedMessage = (TextMessage)receiver1.receive();
+        assertNull(receiver.receive(2000L));
+        TextMessage receivedMessage = (TextMessage)receiver.receive();
         assertTrue(receivedMessage.getJMSDeliveryTime() > 0);
         assertEquals(MESSAGE_TEXT_1, receivedMessage.getText());
 

--- a/src/test/java/com/rabbitmq/integration/tests/DelayedTopicMessageIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/DelayedTopicMessageIT.java
@@ -1,0 +1,61 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2013-2020 VMware, Inc. or its affiliates. All rights reserved.
+package com.rabbitmq.integration.tests;
+
+import com.rabbitmq.jms.util.Shell;
+import jakarta.jms.*;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration test
+ */
+public class DelayedTopicMessageIT extends AbstractITTopic {
+
+    private static final String MESSAGE = "Hello " + DelayedTopicMessageIT.class.getName();
+
+    private static final String TOPIC_NAME = "delay.topic." + DelayedTopicMessageIT.class.getCanonicalName();
+    private static final String WILD_TOPIC_NAME = "delay.topic.#";
+    private static final String MESSAGE_TEXT_1 = "Hello " + DelayedTopicMessageIT.class.getName();
+    private static final String MESSAGE_TEXT_2 = "Wild hello " + DelayedTopicMessageIT.class.getName();
+
+    @BeforeEach
+    public void beforeMethod() throws IOException {
+        try {
+            Shell.rabbitmqPlugins("is_enabled rabbitmq_delayed_message_exchange");
+        }catch(Exception e) {
+            System.out.println("Skipped DelayedMessageIT. Plugin rabbitmq_delayed_message_exchange is not enabled");
+            Assumptions.assumeTrue(false);
+        }
+    }
+    @Test
+    public void testSendAndReceiveTextMessage() throws Exception {
+        topicConn.start();
+        TopicSession topicSession = topicConn.createTopicSession(false, Session.DUPS_OK_ACKNOWLEDGE);
+        Topic topic = topicSession.createTopic(TOPIC_NAME);
+        TopicPublisher sender = topicSession.createPublisher(topic);
+        sender.setDeliveryDelay(1000L);
+        TopicSubscriber receiver1 = topicSession.createSubscriber(topic);
+
+        sender.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
+        TextMessage message = topicSession.createTextMessage(MESSAGE_TEXT_1);
+        sender.send(message);
+
+        TextMessage receivedMessage = (TextMessage)receiver1.receive();
+        assertTrue(receivedMessage.getJMSDeliveryTime() > 0);
+        assertEquals(MESSAGE_TEXT_1, receivedMessage.getText());
+
+    }
+
+
+
+}

--- a/src/test/java/com/rabbitmq/integration/tests/DelayedTopicMessageIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/DelayedTopicMessageIT.java
@@ -13,8 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Integration test
@@ -38,24 +37,25 @@ public class DelayedTopicMessageIT extends AbstractITTopic {
         }
     }
     @Test
-    public void testSendAndReceiveTextMessage() throws Exception {
+    public void testSendMessageToTopicWithDelayedPublisher() throws Exception {
         topicConn.start();
         TopicSession topicSession = topicConn.createTopicSession(false, Session.DUPS_OK_ACKNOWLEDGE);
         Topic topic = topicSession.createTopic(TOPIC_NAME);
         TopicPublisher sender = topicSession.createPublisher(topic);
-        sender.setDeliveryDelay(1000L);
+        sender.setDeliveryDelay(4000L);
         TopicSubscriber receiver1 = topicSession.createSubscriber(topic);
 
+        // TODO probably ensure the topic is empty
         sender.setDeliveryMode(DeliveryMode.NON_PERSISTENT);
         TextMessage message = topicSession.createTextMessage(MESSAGE_TEXT_1);
         sender.send(message);
 
+        assertNull(receiver1.receive(2000L));
         TextMessage receivedMessage = (TextMessage)receiver1.receive();
         assertTrue(receivedMessage.getJMSDeliveryTime() > 0);
         assertEquals(MESSAGE_TEXT_1, receivedMessage.getText());
 
     }
-
 
 
 }

--- a/src/test/java/com/rabbitmq/integration/tests/SSLHostnameVerificationIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/SSLHostnameVerificationIT.java
@@ -7,7 +7,7 @@ package com.rabbitmq.integration.tests;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.rabbitmq.TestUtils.DisabledIfTlsNotEnabled;
+import com.rabbitmq.TestUtils.SkipIfTlsNotActivated;
 import com.rabbitmq.jms.admin.RMQConnectionFactory;
 import java.io.FileInputStream;
 import java.security.KeyStore;
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 /** Integration test for hostname verification with TLS. */
-@DisabledIfTlsNotEnabled
+@SkipIfTlsNotActivated
 @EnabledForJreRange(min = JRE.JAVA_11)
 public class SSLHostnameVerificationIT {
 

--- a/src/test/java/com/rabbitmq/integration/tests/SSLSimpleQueueMessageIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/SSLSimpleQueueMessageIT.java
@@ -5,7 +5,7 @@
 // Copyright (c) 2013-2022 VMware, Inc. or its affiliates. All rights reserved.
 package com.rabbitmq.integration.tests;
 
-import com.rabbitmq.TestUtils.DisabledIfTlsNotEnabled;
+import com.rabbitmq.TestUtils.SkipIfTlsNotActivated;
 import java.io.Serializable;
 
 import jakarta.jms.DeliveryMode;
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Integration test for simple point-to-point messaging.
  */
-@DisabledIfTlsNotEnabled
+@SkipIfTlsNotActivated
 public class SSLSimpleQueueMessageIT extends AbstractITQueueSSL {
 
     private static final String QUEUE_NAME = "test.queue."+SSLSimpleQueueMessageIT.class.getCanonicalName();

--- a/src/test/java/com/rabbitmq/integration/tests/SSLSimpleTopicMessageIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/SSLSimpleTopicMessageIT.java
@@ -7,7 +7,7 @@ package com.rabbitmq.integration.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.rabbitmq.TestUtils.DisabledIfTlsNotEnabled;
+import com.rabbitmq.TestUtils.SkipIfTlsNotActivated;
 import jakarta.jms.DeliveryMode;
 import jakarta.jms.Session;
 import jakarta.jms.TextMessage;
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Integration test
  */
-@DisabledIfTlsNotEnabled
+@SkipIfTlsNotActivated
 public class SSLSimpleTopicMessageIT extends AbstractITTopicSSL {
     private static final String TOPIC_NAME = "test.topic." + SSLSimpleTopicMessageIT.class.getCanonicalName();
 

--- a/src/test/java/com/rabbitmq/integration/tests/SslContextIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/SslContextIT.java
@@ -5,7 +5,7 @@
 // Copyright (c) 2016-2022 VMware, Inc. or its affiliates. All rights reserved.
 package com.rabbitmq.integration.tests;
 
-import com.rabbitmq.TestUtils.DisabledIfTlsNotEnabled;
+import com.rabbitmq.TestUtils.SkipIfTlsNotActivated;
 import com.rabbitmq.jms.admin.RMQConnectionFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisabledIfTlsNotEnabled
+@SkipIfTlsNotActivated
 public class SslContextIT {
 
     Connection connection = null;

--- a/src/test/java/com/rabbitmq/jms/client/DelayedMessageServiceTest.java
+++ b/src/test/java/com/rabbitmq/jms/client/DelayedMessageServiceTest.java
@@ -1,3 +1,8 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2014-2022 VMware, Inc. or its affiliates. All rights reserved.
 package com.rabbitmq.jms.client;
 
 import com.rabbitmq.client.Channel;

--- a/src/test/java/com/rabbitmq/jms/client/DelayedMessageServiceTest.java
+++ b/src/test/java/com/rabbitmq/jms/client/DelayedMessageServiceTest.java
@@ -2,20 +2,23 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 //
-// Copyright (c) 2014-2022 VMware, Inc. or its affiliates. All rights reserved.
+// Copyright (c) 2022 VMware, Inc. or its affiliates. All rights reserved.
 package com.rabbitmq.jms.client;
 
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.impl.AMQImpl;
 import com.rabbitmq.jms.admin.RMQDestination;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
+import org.mockito.Captor;
+import org.mockito.Mock;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import org.mockito.MockitoAnnotations;
 
 import static com.rabbitmq.jms.client.DelayedMessageService.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -24,15 +27,27 @@ import static org.mockito.Mockito.*;
 
 class DelayedMessageServiceTest {
     DelayedMessageService subject;
-    ArgumentCaptor<Map<String, Object>> exchangeDeclarationArgs = ArgumentCaptor.forClass(Map.class);
-    ArgumentCaptor<Map<String, Object>> exchangeBindingArgs = ArgumentCaptor.forClass(Map.class);
-    Channel channel = Mockito.mock(Channel.class);
+
+    @Captor
+    ArgumentCaptor<Map<String, Object>> exchangeDeclarationArgs;
+    @Captor
+    ArgumentCaptor<Map<String, Object>> exchangeBindingArgs;
+
+    @Mock
+    Channel channel;
+    AutoCloseable mocks;
     RMQDestination jmsQueueDestination = new RMQDestination("some-queue", true, false);
     Map<String, Object> msgHeaders = new HashMap<>();
 
     @BeforeEach
     void setUp() {
+        mocks = MockitoAnnotations.openMocks(this);
         subject = new DelayedMessageService();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        mocks.close();
     }
 
     @Test
@@ -83,20 +98,20 @@ class DelayedMessageServiceTest {
 
 
     @Test
-    void shouldReturnTheDelayedExchangeWhenDelayIsGreaterThanZero() throws IOException {
+    void shouldReturnTheDelayedExchangeWhenDelayIsGreaterThanZero() {
         String targetExchange = subject.delayMessage(channel, jmsQueueDestination, msgHeaders, 1000L);
         assertEquals(X_DELAYED_JMS_EXCHANGE, targetExchange);
     }
 
     @Test
-    void shouldAddDelayAndOriginalExchangeToMessageHeaders() throws IOException {
+    void shouldAddDelayAndOriginalExchangeToMessageHeaders() {
         subject.delayMessage(channel, jmsQueueDestination, msgHeaders, 1000L);
         assertEquals(1000L, msgHeaders.get(X_DELAY_HEADER));
         assertEquals(jmsQueueDestination.getAmqpExchangeName(), msgHeaders.get(X_DELAYED_JMS_EXCHANGE_HEADER));
     }
 
     @Test
-    void shouldReturnTheTargetExchangeWhenDelayIsNotGreaterThanZero() throws IOException {
+    void shouldReturnTheTargetExchangeWhenDelayIsNotGreaterThanZero() {
         String targetExchange = subject.delayMessage(channel, jmsQueueDestination, msgHeaders, 0L);
         assertEquals(jmsQueueDestination.getAmqpExchangeName(), targetExchange);
     }

--- a/src/test/java/com/rabbitmq/jms/client/DelayedMessageServiceTest.java
+++ b/src/test/java/com/rabbitmq/jms/client/DelayedMessageServiceTest.java
@@ -1,0 +1,116 @@
+package com.rabbitmq.jms.client;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.impl.AMQImpl;
+import com.rabbitmq.jms.admin.RMQDestination;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.rabbitmq.jms.client.DelayedMessageService.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class DelayedMessageServiceTest {
+    DelayedMessageService subject;
+    ArgumentCaptor<Map<String, Object>> exchangeDeclarationArgs = ArgumentCaptor.forClass(Map.class);
+    ArgumentCaptor<Map<String, Object>> exchangeBindingArgs = ArgumentCaptor.forClass(Map.class);
+    Channel channel = Mockito.mock(Channel.class);
+    RMQDestination jmsQueueDestination = new RMQDestination("some-queue", true, false);
+    Map<String, Object> msgHeaders = new HashMap<>();
+
+    @BeforeEach
+    void setUp() {
+        subject = new DelayedMessageService();
+    }
+
+    @Test
+    void shouldDeclareDelayedExchangeOnce() throws IOException {
+
+        shouldDeclareDelayedExchangeOfTypeHeaders();
+
+        // when we try to send the message again,
+        reset(channel);
+
+        subject.delayMessage(channel, jmsQueueDestination, msgHeaders, 1000L);
+
+        verifyNoInteractions(channel);
+    }
+
+    @Test
+    void shouldDeclareDelayedExchangeOfTypeHeaders() throws IOException {
+
+        shouldDeclareDelayedExchange();
+
+        subject.delayMessage(channel, jmsQueueDestination, msgHeaders, 1000L);
+
+        assertEquals("headers", exchangeDeclarationArgs.getValue().get("x-delayed-type"));
+    }
+
+
+    @Test
+    void shouldBindTargetExchangeToDelayedExchangeOnce() throws IOException {
+
+        shouldBindTargetExchangeToDelayedExchange();
+
+        reset(channel);
+        subject.delayMessage(channel, jmsQueueDestination, msgHeaders, 1000L);
+
+        verifyNoInteractions(channel);
+    }
+
+    @Test
+    void shouldBindTargetExchangeToDelayedExchange() throws IOException {
+
+        shouldBindTargetExchangeToDelayExchange();
+
+        subject.delayMessage(channel, jmsQueueDestination, msgHeaders, 1000L);
+
+        assertEquals(jmsQueueDestination.getAmqpExchangeName(), exchangeBindingArgs.getValue().get(X_DELAYED_JMS_EXCHANGE_HEADER));
+
+    }
+
+
+    @Test
+    void shouldReturnTheDelayedExchangeWhenDelayIsGreaterThanZero() throws IOException {
+        String targetExchange = subject.delayMessage(channel, jmsQueueDestination, msgHeaders, 1000L);
+        assertEquals(X_DELAYED_JMS_EXCHANGE, targetExchange);
+    }
+
+    @Test
+    void shouldAddDelayAndOriginalExchangeToMessageHeaders() throws IOException {
+        subject.delayMessage(channel, jmsQueueDestination, msgHeaders, 1000L);
+        assertEquals(1000L, msgHeaders.get(X_DELAY_HEADER));
+        assertEquals(jmsQueueDestination.getAmqpExchangeName(), msgHeaders.get(X_DELAYED_JMS_EXCHANGE_HEADER));
+    }
+
+    @Test
+    void shouldReturnTheTargetExchangeWhenDelayIsNotGreaterThanZero() throws IOException {
+        String targetExchange = subject.delayMessage(channel, jmsQueueDestination, msgHeaders, 0L);
+        assertEquals(jmsQueueDestination.getAmqpExchangeName(), targetExchange);
+    }
+
+    private void shouldDeclareDelayedExchange() throws IOException {
+        doReturn(new AMQImpl.Exchange.DeclareOk()).when(channel).exchangeDeclare(
+                eq(X_DELAYED_JMS_EXCHANGE),
+                eq("x-delayed-message"),
+                eq(true),
+                eq(false),
+                eq(false),
+                exchangeDeclarationArgs.capture());
+    }
+
+    private void shouldBindTargetExchangeToDelayExchange() throws IOException {
+        doReturn(new AMQImpl.Exchange.BindOk()).when(channel).exchangeBind(
+                eq(jmsQueueDestination.getAmqpExchangeName()),
+                eq(X_DELAYED_JMS_EXCHANGE),
+                eq(""),
+                exchangeBindingArgs.capture());
+    }
+}

--- a/src/test/java/com/rabbitmq/jms/client/RMQMessageProducerTest.java
+++ b/src/test/java/com/rabbitmq/jms/client/RMQMessageProducerTest.java
@@ -5,7 +5,11 @@
 // Copyright (c) 2017-2022 VMware, Inc. or its affiliates. All rights reserved.
 package com.rabbitmq.jms.client;
 
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.BasicProperties;
+import com.rabbitmq.client.Channel;
 import com.rabbitmq.jms.admin.RMQDestination;
+import com.rabbitmq.jms.client.message.RMQBytesMessage;
 import com.rabbitmq.jms.client.message.RMQTextMessage;
 import jakarta.jms.CompletionListener;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,8 +20,10 @@ import jakarta.jms.DeliveryMode;
 import jakarta.jms.JMSException;
 import jakarta.jms.Message;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 /**
  *
@@ -28,8 +34,8 @@ public class RMQMessageProducerTest {
     RMQDestination destination;
 
     @BeforeEach public void init() {
-        session = Mockito.mock(RMQSession.class);
-        destination = Mockito.mock(RMQDestination.class);
+        session = mock(RMQSession.class);
+        destination = mock(RMQDestination.class);
     }
 
     @Test public void preferProducerPropertyNoMessagePropertySpecified() throws Exception {
@@ -111,6 +117,38 @@ public class RMQMessageProducerTest {
         assertEquals(1, message.getJMSPriority());
         assertEquals(expiration, message.getJMSExpiration());
         assertEquals(deliveryTime, message.getJMSDeliveryTime());
+    }
+
+    @Test public void sendDelayedMessageToAMQPDestination() throws JMSException, IOException {
+        RMQBytesMessage bytesMessage = new RMQBytesMessage();        //RMQBytesMessage || RMQTextMessage
+        RMQDestination amqpDestination = new RMQDestination("some-direct-exchange", "some-direct-exchange",
+                "some-routing-key", "some-queue");
+        assertTrue(amqpDestination.isAmqp());
+
+        doReturn("x").when(session).delayMessage(eq(amqpDestination), anyMap(), eq(100L));
+        Channel channel = Mockito.mock(Channel.class);
+        doReturn(channel).when(session).getChannel();
+        RMQMessageProducer producer = new RMQMessageProducer(session, amqpDestination, false);
+        producer.setDeliveryDelay(100L);
+        producer.send(bytesMessage);
+
+        verify(channel).basicPublish(eq("x"), anyString(), any(AMQP.BasicProperties.class), any(byte[].class));
+    }
+
+    @Test public void sendDelayedMessageToJMSDestination() throws JMSException, IOException {
+        RMQBytesMessage bytesMessage = new RMQBytesMessage();        //RMQBytesMessage || RMQTextMessage
+        RMQDestination jmsQueueDestination = new RMQDestination("some-queue", true, false);
+        assertFalse(jmsQueueDestination.isAmqp());
+
+        doReturn("x").when(session).delayMessage(eq(jmsQueueDestination), anyMap(), eq(100L));
+        Channel channel = Mockito.mock(Channel.class);
+        doReturn(channel).when(session).getChannel();
+        RMQMessageProducer producer = new RMQMessageProducer(session, jmsQueueDestination, false);
+        producer.setDeliveryDelay(100L);
+        producer.send(bytesMessage);
+
+        verify(session).declareDestinationIfNecessary(jmsQueueDestination);
+        verify(channel).basicPublish(eq("x"), anyString(), any(AMQP.BasicProperties.class), any(byte[].class));
     }
 
     static class StubRMQMessageProducer extends RMQMessageProducer {

--- a/src/test/java/com/rabbitmq/jms/client/RMQMessageTest.java
+++ b/src/test/java/com/rabbitmq/jms/client/RMQMessageTest.java
@@ -1,3 +1,8 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2014-2022 VMware, Inc. or its affiliates. All rights reserved.
 package com.rabbitmq.jms.client;
 
 import com.rabbitmq.jms.client.message.RMQTextMessage;

--- a/src/test/java/com/rabbitmq/jms/client/RMQSessionTest.java
+++ b/src/test/java/com/rabbitmq/jms/client/RMQSessionTest.java
@@ -1,3 +1,8 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2014-2022 VMware, Inc. or its affiliates. All rights reserved.
 package com.rabbitmq.jms.client;
 
 import com.rabbitmq.client.Channel;

--- a/src/test/java/com/rabbitmq/jms/client/RMQSessionTest.java
+++ b/src/test/java/com/rabbitmq/jms/client/RMQSessionTest.java
@@ -1,0 +1,83 @@
+package com.rabbitmq.jms.client;
+
+import com.rabbitmq.client.AddressResolver;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.impl.AMQImpl;
+import com.rabbitmq.jms.admin.RMQDestination;
+import jakarta.jms.JMSException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.internal.matchers.CapturesArguments;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+
+public class RMQSessionTest {
+
+    RMQSession session;
+    RMQConnection connection;
+    Channel channel;
+
+    RMQDestination destination;
+    Map<String, Object> headers;
+
+    @BeforeEach
+    public void init() throws JMSException, IOException {
+        connection = Mockito.mock(RMQConnection.class);
+        channel = Mockito.mock(Channel.class);
+        Mockito.doReturn(channel).when(connection).createRabbitChannel(false);
+        session = new RMQSession(connection, false, 0, 0, new Subscriptions());
+
+        destination = new RMQDestination("some-exchange", true, false);
+        headers = new HashMap<>();
+    }
+
+    @Test
+    void delayMessage() throws IOException {
+        ArgumentCaptor<Map<String,Object>> delayedExchangeArguments = delayedExchangeShouldBeDeclared();
+        ArgumentCaptor<Map<String,Object>> destinationExchangeBindingArguments = targetDestinationShouldBeBoundToDelayedExchange();
+
+        assertEquals(RMQSession.X_DELAYED_JMS_EXCHANGE,
+                session.delayMessage(destination, headers, 1L));
+        assertEquals(destination.getAmqpExchangeName(), headers.get(RMQSession.X_DELAYED_JMS_EXCHANGE_HEADER));
+        assertEquals(1L, headers.get(RMQSession.X_DELAY_HEADER));
+
+        Mockito.verify(channel);
+        assertEquals("headers", delayedExchangeArguments.getValue().get("x-delayed-type"));
+        assertEquals(destination.getAmqpExchangeName(), destinationExchangeBindingArguments.getValue()
+                .get(RMQSession.X_DELAYED_JMS_EXCHANGE_HEADER));
+    }
+
+    private ArgumentCaptor<Map<String,Object>> delayedExchangeShouldBeDeclared() throws IOException {
+        ArgumentCaptor<Map<String,Object>> argumentCaptor = ArgumentCaptor.forClass(Map.class);
+
+        Mockito.doReturn(new AMQImpl.Exchange.DeclareOk()).when(channel)
+                .exchangeDeclare(eq(RMQSession.X_DELAYED_JMS_EXCHANGE),
+                eq("x-delayed-message"), eq(true), eq(false), eq(false),
+                argumentCaptor.capture()); // object proper
+
+        return argumentCaptor;
+    }
+    private ArgumentCaptor<Map<String,Object>> targetDestinationShouldBeBoundToDelayedExchange() throws IOException {
+        ArgumentCaptor<Map<String,Object>> argumentCaptor = ArgumentCaptor.forClass(Map.class);
+
+        Mockito.doReturn(new AMQImpl.Exchange.BindOk()).when(channel)
+                .exchangeBind(eq(destination.getAmqpExchangeName()), eq(RMQSession.X_DELAYED_JMS_EXCHANGE),
+                        eq(""), argumentCaptor.capture());
+        return argumentCaptor;
+    }
+
+    @Test
+    void skipDelayMessage() {
+        assertEquals(destination.getAmqpExchangeName(), session.delayMessage(destination, headers, 0L));
+        assertTrue(headers.isEmpty());
+    }
+
+}

--- a/src/test/java/com/rabbitmq/jms/client/RMQSessionTest.java
+++ b/src/test/java/com/rabbitmq/jms/client/RMQSessionTest.java
@@ -9,43 +9,63 @@ import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.impl.AMQImpl;
 import com.rabbitmq.jms.admin.RMQDestination;
 import jakarta.jms.JMSException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
+import org.mockito.Captor;
+import org.mockito.Mock;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import org.mockito.MockitoAnnotations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 
 public class RMQSessionTest {
 
-    RMQSession session;
+    @Captor
+    ArgumentCaptor<Map<String,Object>> delayedExchangeArguments;
+    @Captor
+    ArgumentCaptor<Map<String,Object>> destinationExchangeBindingArguments;
+    @Mock
     RMQConnection connection;
+    @Mock
     Channel channel;
+    RMQSession session;
 
     RMQDestination destination;
     Map<String, Object> headers;
+    private AutoCloseable mocks;
 
     @BeforeEach
-    public void init() throws JMSException, IOException {
-        connection = Mockito.mock(RMQConnection.class);
-        channel = Mockito.mock(Channel.class);
-        Mockito.doReturn(channel).when(connection).createRabbitChannel(false);
+    void init() throws JMSException, IOException {
+        mocks = MockitoAnnotations.openMocks(this);
+        doReturn(channel).when(connection).createRabbitChannel(false);
         session = new RMQSession(connection, false, 0, 0, new Subscriptions(), new DelayedMessageService());
 
         destination = new RMQDestination("some-exchange", true, false);
         headers = new HashMap<>();
     }
 
+    @AfterEach
+    void tearDown() throws Exception {
+        mocks.close();
+    }
+
     @Test
     void delayMessage() throws IOException {
-        ArgumentCaptor<Map<String,Object>> delayedExchangeArguments = delayedExchangeShouldBeDeclared();
-        ArgumentCaptor<Map<String,Object>> destinationExchangeBindingArguments = targetDestinationShouldBeBoundToDelayedExchange();
+        doReturn(new AMQImpl.Exchange.DeclareOk()).when(channel)
+            .exchangeDeclare(eq(DelayedMessageService.X_DELAYED_JMS_EXCHANGE),
+                eq("x-delayed-message"), eq(true), eq(false), eq(false),
+                delayedExchangeArguments.capture());
+        doReturn(new AMQImpl.Exchange.BindOk()).when(channel)
+            .exchangeBind(eq(destination.getAmqpExchangeName()), eq(DelayedMessageService.X_DELAYED_JMS_EXCHANGE),
+                eq(""), destinationExchangeBindingArguments.capture());
 
         assertEquals(DelayedMessageService.X_DELAYED_JMS_EXCHANGE,
                 session.delayMessage(destination, headers, 1L));
@@ -55,25 +75,6 @@ public class RMQSessionTest {
         assertEquals("headers", delayedExchangeArguments.getValue().get("x-delayed-type"));
         assertEquals(destination.getAmqpExchangeName(), destinationExchangeBindingArguments.getValue()
                 .get(DelayedMessageService.X_DELAYED_JMS_EXCHANGE_HEADER));
-    }
-
-    private ArgumentCaptor<Map<String,Object>> delayedExchangeShouldBeDeclared() throws IOException {
-        ArgumentCaptor<Map<String,Object>> argumentCaptor = ArgumentCaptor.forClass(Map.class);
-
-        Mockito.doReturn(new AMQImpl.Exchange.DeclareOk()).when(channel)
-                .exchangeDeclare(eq(DelayedMessageService.X_DELAYED_JMS_EXCHANGE),
-                eq("x-delayed-message"), eq(true), eq(false), eq(false),
-                argumentCaptor.capture()); // object proper
-
-        return argumentCaptor;
-    }
-    private ArgumentCaptor<Map<String,Object>> targetDestinationShouldBeBoundToDelayedExchange() throws IOException {
-        ArgumentCaptor<Map<String,Object>> argumentCaptor = ArgumentCaptor.forClass(Map.class);
-
-        Mockito.doReturn(new AMQImpl.Exchange.BindOk()).when(channel)
-                .exchangeBind(eq(destination.getAmqpExchangeName()), eq(DelayedMessageService.X_DELAYED_JMS_EXCHANGE),
-                        eq(""), argumentCaptor.capture());
-        return argumentCaptor;
     }
 
     @Test

--- a/src/test/java/com/rabbitmq/jms/client/RMQSessionTest.java
+++ b/src/test/java/com/rabbitmq/jms/client/RMQSessionTest.java
@@ -1,6 +1,5 @@
 package com.rabbitmq.jms.client;
 
-import com.rabbitmq.client.AddressResolver;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.impl.AMQImpl;
 import com.rabbitmq.jms.admin.RMQDestination;
@@ -9,7 +8,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.mockito.internal.matchers.CapturesArguments;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -33,7 +31,7 @@ public class RMQSessionTest {
         connection = Mockito.mock(RMQConnection.class);
         channel = Mockito.mock(Channel.class);
         Mockito.doReturn(channel).when(connection).createRabbitChannel(false);
-        session = new RMQSession(connection, false, 0, 0, new Subscriptions());
+        session = new RMQSession(connection, false, 0, 0, new Subscriptions(), new DelayedMessageService());
 
         destination = new RMQDestination("some-exchange", true, false);
         headers = new HashMap<>();
@@ -44,21 +42,21 @@ public class RMQSessionTest {
         ArgumentCaptor<Map<String,Object>> delayedExchangeArguments = delayedExchangeShouldBeDeclared();
         ArgumentCaptor<Map<String,Object>> destinationExchangeBindingArguments = targetDestinationShouldBeBoundToDelayedExchange();
 
-        assertEquals(RMQSession.X_DELAYED_JMS_EXCHANGE,
+        assertEquals(DelayedMessageService.X_DELAYED_JMS_EXCHANGE,
                 session.delayMessage(destination, headers, 1L));
-        assertEquals(destination.getAmqpExchangeName(), headers.get(RMQSession.X_DELAYED_JMS_EXCHANGE_HEADER));
-        assertEquals(1L, headers.get(RMQSession.X_DELAY_HEADER));
+        assertEquals(destination.getAmqpExchangeName(), headers.get(DelayedMessageService.X_DELAYED_JMS_EXCHANGE_HEADER));
+        assertEquals(1L, headers.get(DelayedMessageService.X_DELAY_HEADER));
 
         assertEquals("headers", delayedExchangeArguments.getValue().get("x-delayed-type"));
         assertEquals(destination.getAmqpExchangeName(), destinationExchangeBindingArguments.getValue()
-                .get(RMQSession.X_DELAYED_JMS_EXCHANGE_HEADER));
+                .get(DelayedMessageService.X_DELAYED_JMS_EXCHANGE_HEADER));
     }
 
     private ArgumentCaptor<Map<String,Object>> delayedExchangeShouldBeDeclared() throws IOException {
         ArgumentCaptor<Map<String,Object>> argumentCaptor = ArgumentCaptor.forClass(Map.class);
 
         Mockito.doReturn(new AMQImpl.Exchange.DeclareOk()).when(channel)
-                .exchangeDeclare(eq(RMQSession.X_DELAYED_JMS_EXCHANGE),
+                .exchangeDeclare(eq(DelayedMessageService.X_DELAYED_JMS_EXCHANGE),
                 eq("x-delayed-message"), eq(true), eq(false), eq(false),
                 argumentCaptor.capture()); // object proper
 
@@ -68,7 +66,7 @@ public class RMQSessionTest {
         ArgumentCaptor<Map<String,Object>> argumentCaptor = ArgumentCaptor.forClass(Map.class);
 
         Mockito.doReturn(new AMQImpl.Exchange.BindOk()).when(channel)
-                .exchangeBind(eq(destination.getAmqpExchangeName()), eq(RMQSession.X_DELAYED_JMS_EXCHANGE),
+                .exchangeBind(eq(destination.getAmqpExchangeName()), eq(DelayedMessageService.X_DELAYED_JMS_EXCHANGE),
                         eq(""), argumentCaptor.capture());
         return argumentCaptor;
     }

--- a/src/test/java/com/rabbitmq/jms/client/RMQSessionTest.java
+++ b/src/test/java/com/rabbitmq/jms/client/RMQSessionTest.java
@@ -49,7 +49,6 @@ public class RMQSessionTest {
         assertEquals(destination.getAmqpExchangeName(), headers.get(RMQSession.X_DELAYED_JMS_EXCHANGE_HEADER));
         assertEquals(1L, headers.get(RMQSession.X_DELAY_HEADER));
 
-        Mockito.verify(channel);
         assertEquals("headers", delayedExchangeArguments.getValue().get("x-delayed-type"));
         assertEquals(destination.getAmqpExchangeName(), destinationExchangeBindingArguments.getValue()
                 .get(RMQSession.X_DELAYED_JMS_EXCHANGE_HEADER));

--- a/src/test/java/com/rabbitmq/jms/util/Shell.java
+++ b/src/test/java/com/rabbitmq/jms/util/Shell.java
@@ -163,10 +163,6 @@ public class Shell {
     private static String rabbitmqctlNodenameArgument() {
         return isRabbitmqctlOnDocker() ? "" : " -n \'" + nodenameA() + "\'";
     }
-    private static String rabbitmqPluginsNodenameArgument() {
-        return isRabbitmqPluginsOnDocker() ? "" : " -n \'" + nodenameA() + "\'";
-    }
-
     public static boolean isRabbitmqctlOnDocker() {
         String rabbitmqCtl = System.getProperty("rabbitmqctl.bin");
         if (rabbitmqCtl == null) {
@@ -174,18 +170,8 @@ public class Shell {
         }
         return rabbitmqCtl.startsWith(DOCKER_PREFIX);
     }
-    public static boolean isRabbitmqPluginsOnDocker() {
-        String command = System.getProperty("rabbitmq_plugins.bin");
-        if (command == null) {
-            throw new IllegalStateException("Please define the rabbitmq_plugins.bin system property");
-        }
-        return command.startsWith(DOCKER_PREFIX);
-    }
     public static ProcessState rabbitmqctl(String command) throws IOException {
         return executeCommand(rabbitmqctlCommand() + rabbitmqctlNodenameArgument() + " " + command);
-    }
-    public static ProcessState rabbitmqPlugins(String command) throws IOException {
-        return executeCommand(rabbitmqPluginsCommand() + rabbitmqPluginsNodenameArgument() + " " + command);
     }
     public static String rabbitmqctlCommand() {
         String rabbitmqCtl = System.getProperty("rabbitmqctl.bin");
@@ -200,18 +186,6 @@ public class Shell {
         }
     }
 
-    public static String rabbitmqPluginsCommand() {
-        String rabbitmqPlugins = System.getProperty("rabbitmq_plugins.bin");
-        if (rabbitmqPlugins == null) {
-            throw new IllegalStateException("Please define the rabbitmq-plugins.bin system property");
-        }
-        if (rabbitmqPlugins.startsWith("DOCKER:")) {
-            String containerId = rabbitmqPlugins.split(":")[1];
-            return "docker exec " + containerId + " rabbitmq-plugins";
-        } else {
-            return rabbitmqPlugins;
-        }
-    }
     public static class Binding {
 
         private final String source, destination, routingKey;

--- a/src/test/java/com/rabbitmq/jms/util/Shell.java
+++ b/src/test/java/com/rabbitmq/jms/util/Shell.java
@@ -161,21 +161,32 @@ public class Shell {
     }
 
     private static String rabbitmqctlNodenameArgument() {
-        return isOnDocker() ? "" : " -n \'" + nodenameA() + "\'";
+        return isRabbitmqctlOnDocker() ? "" : " -n \'" + nodenameA() + "\'";
+    }
+    private static String rabbitmqPluginsNodenameArgument() {
+        return isRabbitmqPluginsOnDocker() ? "" : " -n \'" + nodenameA() + "\'";
     }
 
-    public static boolean isOnDocker() {
+    public static boolean isRabbitmqctlOnDocker() {
         String rabbitmqCtl = System.getProperty("rabbitmqctl.bin");
         if (rabbitmqCtl == null) {
             throw new IllegalStateException("Please define the rabbitmqctl.bin system property");
         }
         return rabbitmqCtl.startsWith(DOCKER_PREFIX);
     }
-
+    public static boolean isRabbitmqPluginsOnDocker() {
+        String command = System.getProperty("rabbitmq_plugins.bin");
+        if (command == null) {
+            throw new IllegalStateException("Please define the rabbitmq_plugins.bin system property");
+        }
+        return command.startsWith(DOCKER_PREFIX);
+    }
     public static ProcessState rabbitmqctl(String command) throws IOException {
         return executeCommand(rabbitmqctlCommand() + rabbitmqctlNodenameArgument() + " " + command);
     }
-
+    public static ProcessState rabbitmqPlugins(String command) throws IOException {
+        return executeCommand(rabbitmqPluginsCommand() + rabbitmqPluginsNodenameArgument() + " " + command);
+    }
     public static String rabbitmqctlCommand() {
         String rabbitmqCtl = System.getProperty("rabbitmqctl.bin");
         if (rabbitmqCtl == null) {
@@ -189,6 +200,18 @@ public class Shell {
         }
     }
 
+    public static String rabbitmqPluginsCommand() {
+        String rabbitmqPlugins = System.getProperty("rabbitmq_plugins.bin");
+        if (rabbitmqPlugins == null) {
+            throw new IllegalStateException("Please define the rabbitmq-plugins.bin system property");
+        }
+        if (rabbitmqPlugins.startsWith("DOCKER:")) {
+            String containerId = rabbitmqPlugins.split(":")[1];
+            return "docker exec " + containerId + " rabbitmq-plugins";
+        } else {
+            return rabbitmqPlugins;
+        }
+    }
     public static class Binding {
 
         private final String source, destination, routingKey;

--- a/src/test/java/com/rabbitmq/jms/util/Shell.java
+++ b/src/test/java/com/rabbitmq/jms/util/Shell.java
@@ -62,7 +62,7 @@ public class Shell {
         if (lines.length > 0) {
             for (int i = 1; i < lines.length; i++) {
                 String [] fields = lines[i].split("\t");
-                Binding binding = new Binding(fields[0], fields[1], fields[2]);
+                Binding binding = new Binding(fields[0], fields[1], fields.length > 2 ? fields[2] : "");
                 if (includeDefaults || !binding.isDefault()) {
                     bindings.add(binding);
                 }


### PR DESCRIPTION
This PR implements [JMS_Spec-44](https://jakarta.ee/specifications/messaging/3.1/jakarta-messaging-spec-3.1.html#delivery-delay-jms_spec-44) which permits to delay the delivery of a message after a delay or after certain time. 

The implementation depends on the [delayed message exchange](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange) plugin. If the plugin is not enabled, it fails to send any delayed message. 

This is what happens when you send a delayed message to a destination exchange `X`:

1. Declare `x-delayed-jms-message` exchange of type `x-delayed-message` with the args `x-delayed-type : headers`. This means that the delayed exchange is of type **header**. The JMS client caches the declaration at the JMS Connection level.
2. Bind exchange `X` to exchange `x-delayed-jms-message` with the binding argument: `delayed-exchange = X`. The JMS client caches the declaration at the JMS Session level.
3. Send  the message to the destination exchange`x-delayed-jms-message` and add the header `delayed-exchange: X` to the original message
4. The delayed exchange `x-delayed-jms-message`  keeps the message until it expires
5. When the message expires, the delayed exchange routes the message to the binding `delayed-exchange: X` which means the message is sent to the X exchange with its routing key.