### PR TITLE
Handle forwarded Direct Reply To and non-Direct Reply To Q's

### DIFF
--- a/src/main/java/com/rabbitmq/jms/client/RMQMessage.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQMessage.java
@@ -849,7 +849,7 @@ public abstract class RMQMessage implements Message, Cloneable {
         // JMSProperties already set
         message.setReadonly(true);                                              // Set readOnly - mandatory for received messages
 
-        setupJMSReplyTo(message, response.getProps().getReplyTo());
+        maybeSetupDirectReplyTo(message, response.getProps().getReplyTo());
         receivingContextConsumer.accept(new ReceivingContext(message));
 
         return message;
@@ -869,7 +869,7 @@ public abstract class RMQMessage implements Message, Cloneable {
             message.setJMSPropertiesFromAmqpProperties(props);
             message.setReadonly(true);                                              // Set readOnly - mandatory for received messages
 
-            setupJMSReplyTo(message, response.getProps().getReplyTo());
+            maybeSetupDirectReplyTo(message, response.getProps().getReplyTo());
             receivingContextConsumer.accept(new ReceivingContext(message));
 
             return message;
@@ -899,33 +899,23 @@ public abstract class RMQMessage implements Message, Cloneable {
     }
 
     /**
-     * Properly assign JMSReplyTo header when using reply to.
+     * Properly assign JMSReplyTo header when using direct reply to.
      * <p>
      * On a received request message, the AMQP reply-to property is
      * set to a specific <code>amq.rabbitmq.reply-to.ID</code> value.
      * We must use this value for the JMS reply to destination if
      * we want to send the response back to the destination the sender
      * is waiting.
-     * <p>
-     * If we are not using a direct reply to, then assume that the
-     * reply to queue is hosted on the same exchange as the message
-     * being sent.
      *
      * @param message
      * @param replyTo
      * @throws JMSException
      * @since 1.11.0
      */
-    private static void setupJMSReplyTo(RMQMessage message, String replyTo) throws JMSException {
-        if (replyTo != null) {
-            if (replyTo.startsWith(DIRECT_REPLY_TO)) {
-                RMQDestination replyToDestination = new RMQDestination(DIRECT_REPLY_TO, "", replyTo, replyTo);
-                message.setJMSReplyTo(replyToDestination);
-            } else {
-                // If we're not a direct reply-to, assume we're replying on the same exhange as the initial request.
-                RMQDestination replyToDestination = new RMQDestination(replyTo, ((RMQDestination) message.getJMSDestination()).getAmqpExchangeName(), replyTo, replyTo);
-                message.setJMSReplyTo(replyToDestination);
-            }
+    private static void maybeSetupDirectReplyTo(RMQMessage message, String replyTo) throws JMSException {
+        if (replyTo != null && replyTo.startsWith(DIRECT_REPLY_TO)) {
+            RMQDestination replyToDestination = new RMQDestination(DIRECT_REPLY_TO, "", replyTo, replyTo);
+            message.setJMSReplyTo(replyToDestination);
         }
     }
 
@@ -1252,24 +1242,24 @@ public abstract class RMQMessage implements Message, Cloneable {
         this.rmqProperties.put(JMS_MESSAGE_ID, "ID:" + this.internalMessageID);
     }
 
-    /**
-     * Utility method used to be able to write primitives and objects to a data
-     * stream without keeping track of order and type.
-     * <p>
-     * This also allows any Object to be written.
-     * </p>
-     * <p>
-     * The purpose of this method is to optimise the writing of a primitive that
-     * is represented as an object by only writing the type and the primitive
-     * value to the stream.
-     * </p>
-     *
-     * @param s the primitive to be written
-     * @param out the stream to write the primitive to.
-     * @throws IOException if an I/O error occurs
+	/**
+	 * Utility method used to be able to write primitives and objects to a data
+	 * stream without keeping track of order and type.
+	 * <p>
+	 * This also allows any Object to be written.
+	 * </p>
+	 * <p>
+	 * The purpose of this method is to optimise the writing of a primitive that
+	 * is represented as an object by only writing the type and the primitive
+	 * value to the stream.
+	 * </p>
+	 *
+	 * @param s the primitive to be written
+	 * @param out the stream to write the primitive to.
+	 * @throws IOException if an I/O error occurs
      * @throws MessageFormatException if message cannot be parsed
      *
-     */
+	 */
     protected static void writePrimitive(Object s, ObjectOutput out) throws IOException, MessageFormatException {
         writePrimitive(s, out, false);
     }

--- a/src/test/java/com/rabbitmq/jms/client/RMQMessageProducerTest.java
+++ b/src/test/java/com/rabbitmq/jms/client/RMQMessageProducerTest.java
@@ -155,6 +155,7 @@ public class RMQMessageProducerTest {
         verify(channel).basicPublish(eq("x"), anyString(), any(AMQP.BasicProperties.class), any(byte[].class));
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     @DisplayName("RMQMessageProducer::send should ensure that an AMQP message has the correlation id on the rabbit message")
     public void sendAMQPMessageWithCorrelationIdCopy() throws JMSException, IOException {
@@ -181,6 +182,7 @@ public class RMQMessageProducerTest {
         }
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     @DisplayName("RMQMessageProducer::send should ensure that a JMS message has the correlation id on the rabbit message")
     public void sendJMSMessageWithCorrelationIdCopy() throws JMSException, IOException {
@@ -208,6 +210,7 @@ public class RMQMessageProducerTest {
         }
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     @DisplayName("RMQMessageProducer::send should ensure that an AMQP message with a direct reply to is handled correctly")
     public void sendAMQPMessageWithDirectReplyTo() throws JMSException, IOException {
@@ -235,6 +238,7 @@ public class RMQMessageProducerTest {
         }
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     @DisplayName("RMQMessageProducer::send should ensure that an AMQP message with a forwarded direct reply to is handled correctly")
     public void sendAMQPMessageWithDirectReplyToForwardedId() throws JMSException, IOException {
@@ -262,6 +266,7 @@ public class RMQMessageProducerTest {
         }
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     @DisplayName("RMQMessageProducer::send should ensure that an AMQP message with a non-direct reply to is handled correctly")
     public void sendAMQPMessageWithGenericReplyTo() throws JMSException, IOException {
@@ -289,6 +294,7 @@ public class RMQMessageProducerTest {
         }
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     @DisplayName("RMQMessageProducer::send should ensure that a JMS message with a direct reply to is handled correctly")
     public void sendJMSMessageWithDirectReplyTo() throws JMSException, IOException {
@@ -318,6 +324,7 @@ public class RMQMessageProducerTest {
         }
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     @DisplayName("RMQMessageProducer::send should ensure that a JMS message with a forwarded direct reply to is handled correctly")
     public void sendJMSMessageWithDirectReplyToWithForwardedId() throws JMSException, IOException {
@@ -347,7 +354,7 @@ public class RMQMessageProducerTest {
         }
     }
 
-
+    @SuppressWarnings("unchecked")
     @Test
     @DisplayName("RMQMessageProducer::send should ensure that a JMS message with a non-direct reply to is handled correctly")
     public void sendJMSMessageWithGenericReplyTo() throws JMSException, IOException {

--- a/src/test/java/com/rabbitmq/jms/client/RMQMessageTest.java
+++ b/src/test/java/com/rabbitmq/jms/client/RMQMessageTest.java
@@ -5,7 +5,17 @@
 // Copyright (c) 2014-2022 VMware, Inc. or its affiliates. All rights reserved.
 package com.rabbitmq.jms.client;
 
+import com.rabbitmq.client.AMQP.BasicProperties;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Envelope;
+import com.rabbitmq.client.GetResponse;
+import com.rabbitmq.jms.admin.RMQDestination;
 import com.rabbitmq.jms.client.message.RMQTextMessage;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -15,8 +25,22 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class RMQMessageTest {
+
+    RMQSession session;
+    GetResponse getResponse;
+    ReceivingContextConsumer consumer;
+
+    @BeforeEach public void init() {
+        session = mock(RMQSession.class);
+        getResponse = mock(GetResponse.class);
+        consumer = mock(ReceivingContextConsumer.class);
+    }
+
 
     @Test
     @DisplayName("RMQMessage::toAmqpHeaders should convert all properties to amqp headers")
@@ -47,4 +71,95 @@ class RMQMessageTest {
         );
     }
 
+
+    @Test
+    @DisplayName("RMQMessage::convertMessage - amqp message - ensure JMS reply to is null with no replyto")
+    void convertAMQPMessageWithNoReplyTo() throws JMSException {
+
+        BasicProperties props = mock(BasicProperties.class);
+        Envelope envelope = mock(Envelope.class);
+
+        when(getResponse.getProps()).thenReturn(props);
+        when(getResponse.getEnvelope()).thenReturn(envelope);
+        when(envelope.isRedeliver()).thenReturn(false);
+
+        RMQDestination destination = new RMQDestination("dest", "exch", "key", "queue");
+        destination.setAmqp(true);
+
+        RMQMessage result = RMQMessage.convertMessage(session, destination, getResponse, consumer);
+
+        assertNull(result.getJMSReplyTo());
+    }
+
+    @Test
+    @DisplayName("RMQMessage::convertMessage - amqp message - ensure JMS reply to is set to direct reply to")
+    void convertAMQPMessageWithDirectReplyTo() throws JMSException {
+
+        BasicProperties props = mock(BasicProperties.class);
+        Envelope envelope = mock(Envelope.class);
+
+        when(getResponse.getProps()).thenReturn(props);
+        when(getResponse.getEnvelope()).thenReturn(envelope);
+        when(envelope.isRedeliver()).thenReturn(false);
+
+        when(props.getReplyTo()).thenReturn("amq.rabbitmq.reply-to");
+
+        RMQDestination destination = new RMQDestination("dest", "exch", "key", "queue");
+        destination.setAmqp(true);
+
+        RMQMessage result = RMQMessage.convertMessage(session, destination, getResponse, consumer);
+
+        assertNotNull(result.getJMSReplyTo());
+
+        RMQDestination expected = new RMQDestination("amq.rabbitmq.reply-to", "", "amq.rabbitmq.reply-to", "amq.rabbitmq.reply-to");
+        assertEquals(expected, result.getJMSReplyTo());
+    }
+
+    @Test
+    @DisplayName("RMQMessage::convertMessage - amqp message - ensure JMS reply to is set to the forwarded direct reply to")
+    void convertAMQPMessageWithForwardedDirectReplyTo() throws JMSException {
+
+        BasicProperties props = mock(BasicProperties.class);
+        Envelope envelope = mock(Envelope.class);
+
+        when(getResponse.getProps()).thenReturn(props);
+        when(getResponse.getEnvelope()).thenReturn(envelope);
+        when(envelope.isRedeliver()).thenReturn(false);
+
+        when(props.getReplyTo()).thenReturn("amq.rabbitmq.reply-to-forwarded-id");
+
+        RMQDestination destination = new RMQDestination("dest", "exch", "key", "queue");
+        destination.setAmqp(true);
+
+        RMQMessage result = RMQMessage.convertMessage(session, destination, getResponse, consumer);
+
+        assertNotNull(result.getJMSReplyTo());
+
+        RMQDestination expected = new RMQDestination("amq.rabbitmq.reply-to", "", "amq.rabbitmq.reply-to-forwarded-id", "amq.rabbitmq.reply-to-forwarded-id");
+        assertEquals(expected, result.getJMSReplyTo());
+    }
+
+    @Test
+    @DisplayName("RMQMessage::convertMessage - amqp message - ensure JMS reply to is set to the non direct reply to")
+    void convertAMQPMessageWithNonDirectReplyTo() throws JMSException {
+
+        BasicProperties props = mock(BasicProperties.class);
+        Envelope envelope = mock(Envelope.class);
+
+        when(getResponse.getProps()).thenReturn(props);
+        when(getResponse.getEnvelope()).thenReturn(envelope);
+        when(envelope.isRedeliver()).thenReturn(false);
+
+        when(props.getReplyTo()).thenReturn("non-direct-replyto");
+
+        RMQDestination destination = new RMQDestination("dest", "exch", "key", "queue");
+        destination.setAmqp(true);
+
+        RMQMessage result = RMQMessage.convertMessage(session, destination, getResponse, consumer);
+
+        assertNotNull(result.getJMSReplyTo());
+
+        RMQDestination expected = new RMQDestination("non-direct-replyto", "exch", "non-direct-replyto", "non-direct-replyto");
+        assertEquals(expected, result.getJMSReplyTo());
+    }
 }

--- a/src/test/java/com/rabbitmq/jms/client/RMQMessageTest.java
+++ b/src/test/java/com/rabbitmq/jms/client/RMQMessageTest.java
@@ -157,9 +157,6 @@ class RMQMessageTest {
 
         RMQMessage result = RMQMessage.convertMessage(session, destination, getResponse, consumer);
 
-        assertNotNull(result.getJMSReplyTo());
-
-        RMQDestination expected = new RMQDestination("non-direct-replyto", "exch", "non-direct-replyto", "non-direct-replyto");
-        assertEquals(expected, result.getJMSReplyTo());
+        assertNull(result.getJMSReplyTo());
     }
 }


### PR DESCRIPTION
Reason for update - we have a system that uses IBMMQ via JMS and are converting some operations to use RabbitMQ, rather than IBMMQ. To be able to maintain backwards compatibility and remain technology agnostic, we're using the Rabbit-JMS-Client. rather than than the native rabbitmq client.

This update is a bug fix for allowing the rabbitmq-jms-client to correctly respond to handle the following use cases:

 - Replying correctly to a message containing a direct reply to queue by ensuring the rabbit correlation id is set (as well as the JMS Correllation id).

 - Forwarding on a message containing a direct reply to queue to a further consumer where a future consumer will reply to the initial client.

 - Handling a reply to queue that's not a "direct reply to" or a forwarded
   "direct reply to" queue.

Change Details

RMQMessageProducer:

 - Replying to a direct reply to - this has been acheived by ensuring that the JMSCorrelationId is set as the rabbit mq correllation id, as well as being set as the jms property form of the correlation id

 - Rename maybeSetReplyToPropertyToDirectReplyTo to setReplyToProperty to allow any reply to queue to be sent onto the consumer, not just direct reply to initialisations. This allows the rabbit-jms-client to handle forwarded direct-reply-to and non-direct reply to destinations.

RMQMessage:

 - Rename maybeSetupDirectReplyTo to setupJMSReplyTo and update to be able to handle non-direct reply to queues. This code assumes that the reply to queue will be hosted on the same exchange as the messaging being sent

   I'm not sure if this is a valid assumption or whether this should potentially allow the use of:

     - 'reply to queue name' - Use the same exchange

     - 'reply to queue name'/'exchange name' - Allow an exchange name
       to be set for the reply to queue.