### PR TITLE
Add pluggable strategy for dealing with reply to queues.

### DIFF
--- a/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
@@ -11,10 +11,12 @@ import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.MetricsCollector;
 import com.rabbitmq.jms.client.ConfirmListener;
 import com.rabbitmq.jms.client.ConnectionParams;
+import com.rabbitmq.jms.client.DefaultReplyToStrategy;
 import com.rabbitmq.jms.client.RMQConnection;
 import com.rabbitmq.jms.client.RMQMessage;
 import com.rabbitmq.jms.client.ReceivingContext;
 import com.rabbitmq.jms.client.ReceivingContextConsumer;
+import com.rabbitmq.jms.client.ReplyToStrategy;
 import com.rabbitmq.jms.client.RmqJmsContext;
 import com.rabbitmq.jms.client.SendingContext;
 import com.rabbitmq.jms.client.SendingContextConsumer;
@@ -264,6 +266,14 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
   private boolean validateSubscriptionNames = false;
 
     /**
+     * The strategy to applied to reply to queue handling. Defaults to handling
+     * "amq.rabbitmq.reply-to" queues.
+     *
+     * @since 2.9.0
+     */
+    private ReplyToStrategy replyToStrategy = DefaultReplyToStrategy.INSTANCE;
+
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -345,6 +355,7 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
             .setRequeueOnTimeout(this.requeueOnTimeout)
             .setKeepTextMessageType(this.keepTextMessageType)
             .setValidateSubscriptionNames(this.validateSubscriptionNames)
+            .setReplyToStrategy(replyToStrategy)
         );
         logger.debug("Connection {} created.", conn);
         return conn;
@@ -1057,6 +1068,26 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
      */
     public void setDeclareReplyToDestination(boolean declareReplyToDestination) {
         this.declareReplyToDestination = declareReplyToDestination;
+    }
+
+    /**
+     * Sets the strategy to use when receiving messages with a reply to
+     * specified.
+     *
+     * @param replyToStrategy The reply to strategy.
+     */
+    public void setReplyToStrategy(final ReplyToStrategy replyToStrategy) {
+        this.replyToStrategy = replyToStrategy;
+    }
+
+    /**
+     * Gets ths reply to strategy to use when receiving messages with a
+     * reply to specified.
+     *
+     * @return  The strategy.
+     */
+    public ReplyToStrategy getReplyToStrategy() {
+        return replyToStrategy;
     }
 
     /**

--- a/src/main/java/com/rabbitmq/jms/client/ConnectionParams.java
+++ b/src/main/java/com/rabbitmq/jms/client/ConnectionParams.java
@@ -119,6 +119,14 @@ public class ConnectionParams {
 
     private boolean validateSubscriptionNames = false;
 
+    /**
+     * The reply to strategy to use when dealing with received messages
+     * with a reply to specified.
+     *
+     * @since 2.9.0
+     */
+    private ReplyToStrategy replyToStrategy = DefaultReplyToStrategy.INSTANCE;
+
     public Connection getRabbitConnection() {
         return rabbitConnection;
     }
@@ -270,5 +278,14 @@ public class ConnectionParams {
 
     public boolean isValidateSubscriptionNames() {
         return validateSubscriptionNames;
+    }
+
+    public ConnectionParams setReplyToStrategy(final ReplyToStrategy replyToStrategy) {
+        this.replyToStrategy = replyToStrategy;
+        return this;
+    }
+
+    public ReplyToStrategy getReplyToStrategy() {
+        return replyToStrategy;
     }
 }

--- a/src/main/java/com/rabbitmq/jms/client/DefaultReplyToStrategy.java
+++ b/src/main/java/com/rabbitmq/jms/client/DefaultReplyToStrategy.java
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2016-2022 VMware, Inc. or its affiliates. All rights reserved.
+package com.rabbitmq.jms.client;
+
+import javax.jms.JMSException;
+
+import com.rabbitmq.jms.admin.RMQDestination;
+
+/**
+ * Default implementation of the reply to strategy.
+ * <b>
+ * This will ensure that any reply to queues using the
+ * amq.rabbitmq.reply-to.<id> are correctly created.
+ *
+ * @since 2.9.0
+ */
+public class DefaultReplyToStrategy implements ReplyToStrategy {
+
+    private static final long serialVersionUID = -496756742546656456L;
+
+    /** An instance of the strategy to avoid having to create multiple copies of the object. */
+    public static final DefaultReplyToStrategy INSTANCE = new DefaultReplyToStrategy();
+
+    /**
+     * Handles the reply to on a received message.
+     *
+     * @param message  The RMQMessage that has been received.
+     * @param replyTo  The reply to queue value received.
+     * @throws JMSException  if there's an issue updating the RMQMessage
+     */
+    @Override
+    public void handleReplyTo(
+            final RMQDestination dest,
+            final RMQMessage message,
+            final String replyTo) throws JMSException {
+
+        if (replyTo != null && replyTo.startsWith(DIRECT_REPLY_TO)) {
+            message.setJMSReplyTo(new RMQDestination(DIRECT_REPLY_TO, "", replyTo, replyTo));
+        }
+    }
+}

--- a/src/main/java/com/rabbitmq/jms/client/RMQConnection.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQConnection.java
@@ -164,6 +164,14 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
     private final DelayedMessageService delayedMessageService;
 
     /**
+     * The reply to strategy to use when handling reply to properties
+     * on received messages.
+     *
+     * @Since 2.9.0
+     */
+    private final ReplyToStrategy replyToStrategy;
+
+    /**
      * Creates an RMQConnection object.
      * @param connectionParams parameters for this connection
      */
@@ -192,6 +200,7 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
         this.keepTextMessageType = connectionParams.isKeepTextMessageType();
         this.validateSubscriptionNames = connectionParams.isValidateSubscriptionNames();
         this.delayedMessageService = new DelayedMessageService();
+        this.replyToStrategy = connectionParams.getReplyToStrategy();
     }
 
     /**
@@ -250,6 +259,7 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
             .setKeepTextMessageType(this.keepTextMessageType)
             .setValidateSubscriptionNames(this.validateSubscriptionNames)
             .setDelayedMessageService(this.delayedMessageService)
+            .setReplyToStrategy(this.replyToStrategy)
         );
         this.sessions.add(session);
         return session;
@@ -563,5 +573,17 @@ public class RMQConnection implements Connection, QueueConnection, TopicConnecti
         String subscriptionName, String messageSelector, ServerSessionPool sessionPool,
         int maxMessages) {
         throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Gets the reply to strategy that should be followed if as reply to is
+     * found on a received message.
+     *
+     * @return  The reply to strategy.
+     *
+     * @since 2.9.0
+     */
+    public ReplyToStrategy getReplyToStrategy() {
+        return replyToStrategy;
     }
 }

--- a/src/main/java/com/rabbitmq/jms/client/RMQSession.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQSession.java
@@ -218,6 +218,15 @@ public class RMQSession implements Session, QueueSession, TopicSession {
 
     private final DelayedMessageService delayedMessageService;
 
+    /**
+     * The reply to strategy to use when dealing with received messages
+     * with a reply to specified.
+     *
+     * @since 2.9.0
+     */
+    private final ReplyToStrategy replyToStrategy;
+
+
     static boolean validateSessionMode(int sessionMode) {
        return sessionMode >= 0 && sessionMode <= CLIENT_INDIVIDUAL_ACKNOWLEDGE;
     }
@@ -266,6 +275,8 @@ public class RMQSession implements Session, QueueSession, TopicSession {
         }
         this.delayedMessageService = sessionParams.getDelayedMessageService();
 
+        this.replyToStrategy = sessionParams.getReplyToStrategy();
+
         if (transacted) {
             this.acknowledgeMode = Session.SESSION_TRANSACTED;
             this.isIndividualAck = false;
@@ -310,6 +321,7 @@ public class RMQSession implements Session, QueueSession, TopicSession {
             .setMode(mode)
             .setSubscriptions(subscriptions)
             .setDelayedMessageService(delayedMessageService)
+            .setReplyToStrategy(connection.getReplyToStrategy())
         );
     }
 
@@ -1468,4 +1480,17 @@ public class RMQSession implements Session, QueueSession, TopicSession {
         void validate(String name) throws JMSException;
 
     }
+
+    /**
+     * Gets the reply to strategy that should be followed if as reply to is
+     * found on a received message.
+     *
+     * @return  The reply to strategy.
+     *
+     * @since 2.9.0
+     */
+    public ReplyToStrategy getReplyToStrategy() {
+        return replyToStrategy;
+    }
+
 }

--- a/src/main/java/com/rabbitmq/jms/client/ReplyToStrategy.java
+++ b/src/main/java/com/rabbitmq/jms/client/ReplyToStrategy.java
@@ -1,0 +1,35 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2016-2022 VMware, Inc. or its affiliates. All rights reserved.
+package com.rabbitmq.jms.client;
+
+import java.io.Serializable;
+
+import javax.jms.JMSException;
+
+import com.rabbitmq.jms.admin.RMQDestination;
+
+/**
+ * Interface to provide a plugable mechanism for dealing with messages
+ * received with a reply to queue specified.
+ * <b>
+ * Implementations of this interface should update the message's JMSReplyTo
+ * property directly.
+ *
+ * @since 2.9.0
+ */
+public interface ReplyToStrategy extends Serializable {
+
+    public static final String DIRECT_REPLY_TO = "amq.rabbitmq.reply-to";
+
+    /**
+     * Handles the reply to on a received message.
+     *
+     * @param message  The RMQMessage that has been received.
+     * @param replyTo  The reply to queue value received.
+     * @throws JMSException  if there's an issue updating the RMQMessage
+     */
+    void handleReplyTo(RMQDestination dest, RMQMessage message, String replyTo) throws JMSException;
+}

--- a/src/main/java/com/rabbitmq/jms/client/ReturnToSenderExchangeReplyToStrategy.java
+++ b/src/main/java/com/rabbitmq/jms/client/ReturnToSenderExchangeReplyToStrategy.java
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2016-2022 VMware, Inc. or its affiliates. All rights reserved.
+package com.rabbitmq.jms.client;
+
+import javax.jms.JMSException;
+
+import com.rabbitmq.jms.admin.RMQDestination;
+
+/**
+ * Default implementation of the reply to strategy.
+ * <b>
+ * This will ensure that any reply to queues using the
+ * amq.rabbitmq.reply-to.<id> are correctly created.
+ *
+ * @since 2.9.0
+ */
+public class ReturnToSenderExchangeReplyToStrategy implements ReplyToStrategy {
+
+    private static final long serialVersionUID = -496756742546656456L;
+
+    /** An instance of the strategy to avoid having to create multiple copies of the object. */
+    public static final ReturnToSenderExchangeReplyToStrategy INSTANCE = new ReturnToSenderExchangeReplyToStrategy();
+
+    /**
+     * Handles the reply to on a received message.
+     *
+     * @param message  The RMQMessage that has been received.
+     * @param replyTo  The reply to queue value received.
+     * @throws JMSException  if there's an issue updating the RMQMessage
+     */
+    @Override
+    public void handleReplyTo(
+            final RMQDestination dest,
+            final RMQMessage message,
+            final String replyTo) throws JMSException {
+
+        if (replyTo != null && "".equals(replyTo) == false) {
+            if (replyTo.startsWith(DIRECT_REPLY_TO)) {
+                message.setJMSReplyTo(new RMQDestination(DIRECT_REPLY_TO, "", replyTo, replyTo));
+            } else {
+                message.setJMSReplyTo(new RMQDestination(replyTo, dest.getAmqpExchangeName(), replyTo, replyTo));
+            }
+        }
+    }
+}

--- a/src/main/java/com/rabbitmq/jms/client/SessionParams.java
+++ b/src/main/java/com/rabbitmq/jms/client/SessionParams.java
@@ -116,6 +116,14 @@ public class SessionParams {
 
     private DelayedMessageService delayedMessageService;
 
+    /**
+     * The reply to strategy to use when processing a received
+     * message with a reply to property.
+     *
+     * @Since 2.9.0
+     */
+    private ReplyToStrategy replyToStrategy = DefaultReplyToStrategy.INSTANCE;
+
     public RMQConnection getConnection() {
         return connection;
     }
@@ -276,5 +284,14 @@ public class SessionParams {
     public SessionParams setDelayedMessageService(DelayedMessageService delayedMessageService) {
         this.delayedMessageService = delayedMessageService;
         return this;
+    }
+
+    public SessionParams setReplyToStrategy(final ReplyToStrategy replyToStrategy) {
+        this.replyToStrategy = replyToStrategy;
+        return this;
+    }
+
+    public ReplyToStrategy getReplyToStrategy() {
+        return replyToStrategy;
     }
 }

--- a/src/test/java/com/rabbitmq/jms/client/ConnectionParamsTest.java
+++ b/src/test/java/com/rabbitmq/jms/client/ConnectionParamsTest.java
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2016-2022 VMware, Inc. or its affiliates. All rights reserved.
+package com.rabbitmq.jms.client;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+public class ConnectionParamsTest {
+
+    @Test
+    void  createNoExplicitReplyToStrategy() {
+        ConnectionParams params = new ConnectionParams();
+
+        assertSame(DefaultReplyToStrategy.INSTANCE, params.getReplyToStrategy());
+    }
+
+    @Test
+    void  createNullReplyToStrategy() {
+        ConnectionParams params = new ConnectionParams();
+        params.setReplyToStrategy(null);
+
+        assertNull(params.getReplyToStrategy());
+    }
+
+    @Test
+    void  createExplicitlySetReplyToStrategy() {
+        ConnectionParams params = new ConnectionParams();
+        params.setReplyToStrategy(ReturnToSenderExchangeReplyToStrategy.INSTANCE);
+
+        assertSame(ReturnToSenderExchangeReplyToStrategy.INSTANCE, params.getReplyToStrategy());
+    }
+}
+
+

--- a/src/test/java/com/rabbitmq/jms/client/DefaultReplyToStrategyTest.java
+++ b/src/test/java/com/rabbitmq/jms/client/DefaultReplyToStrategyTest.java
@@ -1,0 +1,83 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2023 VMware, Inc. or its affiliates. All rights reserved.
+package com.rabbitmq.jms.client;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import javax.jms.JMSException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.rabbitmq.jms.admin.RMQDestination;
+
+public class DefaultReplyToStrategyTest {
+
+    DefaultReplyToStrategy strategy;
+
+    RMQMessage message;
+
+    RMQDestination destination;
+
+    @BeforeEach
+    void setUp() {
+        strategy = new DefaultReplyToStrategy();
+        message = mock(RMQMessage.class);
+        destination = mock(RMQDestination.class);
+    }
+
+
+    @Test
+    void noReplyTo() throws JMSException {
+
+        strategy.handleReplyTo(destination, message, null);
+
+        verifyNoInteractions(destination, message);
+    }
+
+    @Test
+    void emptyReplyTo() throws JMSException {
+
+        strategy.handleReplyTo(destination, message, "");
+
+        verifyNoInteractions(destination, message);
+    }
+
+    @Test
+    void nonDirctReplyTo() throws JMSException {
+
+        strategy.handleReplyTo(destination, message, "non direct reply to");
+
+        verifyNoInteractions(destination, message);
+    }
+
+    @Test
+    void directReplyTo() throws JMSException {
+
+        strategy.handleReplyTo(destination, message, ReplyToStrategy.DIRECT_REPLY_TO);
+
+        RMQDestination d = new RMQDestination(ReplyToStrategy.DIRECT_REPLY_TO, "", ReplyToStrategy.DIRECT_REPLY_TO, ReplyToStrategy.DIRECT_REPLY_TO);
+
+        verify(message).setJMSReplyTo(d);
+        verifyNoMoreInteractions(message);
+        verifyNoInteractions(destination);
+    }
+
+    @Test
+    void directReplyToqueue() throws JMSException {
+
+        strategy.handleReplyTo(destination, message, ReplyToStrategy.DIRECT_REPLY_TO + "-123456678");
+
+        RMQDestination d = new RMQDestination(ReplyToStrategy.DIRECT_REPLY_TO, "", ReplyToStrategy.DIRECT_REPLY_TO  + "-123456678", ReplyToStrategy.DIRECT_REPLY_TO + "-123456678");
+
+        verify(message).setJMSReplyTo(d);
+        verifyNoMoreInteractions(message);
+        verifyNoInteractions(destination);
+    }
+}

--- a/src/test/java/com/rabbitmq/jms/client/RMQMessageTest.java
+++ b/src/test/java/com/rabbitmq/jms/client/RMQMessageTest.java
@@ -101,6 +101,31 @@ class RMQMessageTest {
         when(getResponse.getProps()).thenReturn(props);
         when(getResponse.getEnvelope()).thenReturn(envelope);
         when(envelope.isRedeliver()).thenReturn(false);
+        when(session.getReplyToStrategy()).thenReturn(DefaultReplyToStrategy.INSTANCE);
+
+        when(props.getReplyTo()).thenReturn("amq.rabbitmq.reply-to");
+
+        RMQDestination destination = new RMQDestination("dest", "exch", "key", "queue");
+        destination.setAmqp(true);
+
+        RMQMessage result = RMQMessage.convertMessage(session, destination, getResponse, consumer);
+
+        assertNotNull(result.getJMSReplyTo());
+
+        RMQDestination expected = new RMQDestination("amq.rabbitmq.reply-to", "", "amq.rabbitmq.reply-to", "amq.rabbitmq.reply-to");
+        assertEquals(expected, result.getJMSReplyTo());
+    }
+
+    @Test
+    @DisplayName("RMQMessage::convertMessage - amqp message - ensure JMS reply to is set to direct reply to")
+    void convertAMQPMessageWithDirectReplyToNoExplicityReplyToStrategy() throws JMSException {
+
+        BasicProperties props = mock(BasicProperties.class);
+        Envelope envelope = mock(Envelope.class);
+
+        when(getResponse.getProps()).thenReturn(props);
+        when(getResponse.getEnvelope()).thenReturn(envelope);
+        when(envelope.isRedeliver()).thenReturn(false);
 
         when(props.getReplyTo()).thenReturn("amq.rabbitmq.reply-to");
 
@@ -125,7 +150,7 @@ class RMQMessageTest {
         when(getResponse.getProps()).thenReturn(props);
         when(getResponse.getEnvelope()).thenReturn(envelope);
         when(envelope.isRedeliver()).thenReturn(false);
-
+        when(session.getReplyToStrategy()).thenReturn(DefaultReplyToStrategy.INSTANCE);
         when(props.getReplyTo()).thenReturn("amq.rabbitmq.reply-to-forwarded-id");
 
         RMQDestination destination = new RMQDestination("dest", "exch", "key", "queue");

--- a/src/test/java/com/rabbitmq/jms/client/RMQSessionTest.java
+++ b/src/test/java/com/rabbitmq/jms/client/RMQSessionTest.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import org.mockito.MockitoAnnotations;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -83,4 +85,39 @@ public class RMQSessionTest {
         assertTrue(headers.isEmpty());
     }
 
+    @Test
+    void withReplyToStrategy() throws JMSException {
+
+        SessionParams params = new SessionParams();
+        params.setReplyToStrategy(ReturnToSenderExchangeReplyToStrategy.INSTANCE);
+        params.setConnection(connection);
+
+        RMQSession session = new RMQSession(params);
+
+        assertSame(ReturnToSenderExchangeReplyToStrategy.INSTANCE, session.getReplyToStrategy());
+    }
+
+    @Test
+    void withNoReplyToStrategy() throws JMSException {
+
+        SessionParams params = new SessionParams();
+        params.setConnection(connection);
+
+        RMQSession session = new RMQSession(params);
+
+        assertSame(DefaultReplyToStrategy.INSTANCE, session.getReplyToStrategy());
+    }
+
+
+    @Test
+    void withNullReplyToStrategy() throws JMSException {
+
+        SessionParams params = new SessionParams();
+        params.setReplyToStrategy(null);
+        params.setConnection(connection);
+
+        RMQSession session = new RMQSession(params);
+
+        assertNull(session.getReplyToStrategy());
+    }
 }

--- a/src/test/java/com/rabbitmq/jms/client/ReturnToSenderExchangeReplyToStrategyTest.java
+++ b/src/test/java/com/rabbitmq/jms/client/ReturnToSenderExchangeReplyToStrategyTest.java
@@ -1,0 +1,91 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2023 VMware, Inc. or its affiliates. All rights reserved.
+package com.rabbitmq.jms.client;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import javax.jms.JMSException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.rabbitmq.jms.admin.RMQDestination;
+
+public class ReturnToSenderExchangeReplyToStrategyTest {
+
+    ReturnToSenderExchangeReplyToStrategy strategy;
+
+    RMQMessage message;
+
+    RMQDestination destination;
+
+    @BeforeEach
+    void setUp() {
+        strategy = new ReturnToSenderExchangeReplyToStrategy();
+        message = mock(RMQMessage.class);
+        destination = mock(RMQDestination.class);
+    }
+
+
+    @Test
+    void noReplyTo() throws JMSException {
+
+        strategy.handleReplyTo(destination, message, null);
+
+        verifyNoInteractions(destination, message);
+    }
+
+    @Test
+    void emptyReplyTo() throws JMSException {
+
+        strategy.handleReplyTo(destination, message, "");
+
+        verifyNoInteractions(destination, message);
+    }
+
+    @Test
+    void nonDirctReplyTo() throws JMSException {
+
+        when(destination.getAmqpExchangeName()).thenReturn("exchange");
+
+        strategy.handleReplyTo(destination, message, "non direct reply to");
+
+        when(destination.getAmqpExchangeName()).thenReturn("exchange");
+        RMQDestination d = new RMQDestination("non direct reply to", "exchange", "non direct reply to", "non direct reply to");
+
+        verify(message).setJMSReplyTo(d);
+        verify(destination).getAmqpExchangeName();
+        verifyNoMoreInteractions(destination, message);
+    }
+
+    @Test
+    void directReplyTo() throws JMSException {
+
+        strategy.handleReplyTo(destination, message, ReplyToStrategy.DIRECT_REPLY_TO);
+
+        RMQDestination d = new RMQDestination(ReplyToStrategy.DIRECT_REPLY_TO, "", ReplyToStrategy.DIRECT_REPLY_TO, ReplyToStrategy.DIRECT_REPLY_TO);
+
+        verify(message).setJMSReplyTo(d);
+        verifyNoMoreInteractions(message);
+        verifyNoInteractions(destination);
+    }
+
+    @Test
+    void directReplyToqueue() throws JMSException {
+
+        strategy.handleReplyTo(destination, message, ReplyToStrategy.DIRECT_REPLY_TO + "-123456678");
+
+        RMQDestination d = new RMQDestination(ReplyToStrategy.DIRECT_REPLY_TO, "", ReplyToStrategy.DIRECT_REPLY_TO  + "-123456678", ReplyToStrategy.DIRECT_REPLY_TO + "-123456678");
+
+        verify(message).setJMSReplyTo(d);
+        verifyNoMoreInteractions(message);
+        verifyNoInteractions(destination);
+    }
+}

--- a/src/test/java/com/rabbitmq/jms/client/SessionParamsTest.java
+++ b/src/test/java/com/rabbitmq/jms/client/SessionParamsTest.java
@@ -1,0 +1,39 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2016-2022 VMware, Inc. or its affiliates. All rights reserved.
+package com.rabbitmq.jms.client;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+public class SessionParamsTest {
+
+    @Test
+    void  createNoExplicitReplyToStrategy() {
+        SessionParams params = new SessionParams();
+
+        assertSame(DefaultReplyToStrategy.INSTANCE, params.getReplyToStrategy());
+    }
+
+    @Test
+    void  createNullReplyToStrategy() {
+        SessionParams params = new SessionParams();
+        params.setReplyToStrategy(null);
+
+        assertNull(params.getReplyToStrategy());
+    }
+
+    @Test
+    void  createExplicitlySetReplyToStrategy() {
+        SessionParams params = new SessionParams();
+        params.setReplyToStrategy(ReturnToSenderExchangeReplyToStrategy.INSTANCE);
+
+        assertSame(ReturnToSenderExchangeReplyToStrategy.INSTANCE, params.getReplyToStrategy());
+    }
+}
+
+


### PR DESCRIPTION
Add a pluggable strategy for handling reply-to properties when messages are received with a reply-to specified.

This will default to the standard behaviour of just handling "amq.rabbitmq.reply-to" destinations.

An alternative strategy, ReturnToSenderExchangeReplyToStrategy, has also been implemented that assumes that reply-to queues, if not "amq.rabbitmq.reply-to", are to be returned on the same exchange as the received message.

An alternative reply-to strategy can be set on the connection factory using the setReplyToStrategy method.

For a little background, we have a component that is insisting on using temporary queues (created with no name) as a reply to property. As the reply to queues in rabbit MQ can be rather ambiguous as to what exchange the client expects a response to be send over, I've added pluggable behaviour to the rabbitmq client, which defaults to the existing behaviour.

I've tried to follow keep the flow and setting of the strategy in keeping with how the rest of the jms client is configured, but I'm happy to change or rename classes if needed.