### PR TITLE
Fix: NPE if a received message is marked as "Redelivered" but no header is given

### DIFF
--- a/src/main/java/com/rabbitmq/jms/client/RMQMessage.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQMessage.java
@@ -882,7 +882,7 @@ public abstract class RMQMessage implements Message, Cloneable {
         message.setJMSRedelivered(redelivered);
         if (redelivered) {
             Map<String, Object> headers = response.getProps().getHeaders();
-			Number deliveryCount = headers != null ? (Number) headers.get("x-delivery-count") : null;
+            Number deliveryCount = headers != null ? (Number) headers.get("x-delivery-count") : null;
             if (deliveryCount == null) {
                 message.setIntProperty(JMS_X_DELIVERY_COUNT, 2);
             } else {

--- a/src/main/java/com/rabbitmq/jms/client/RMQMessage.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQMessage.java
@@ -881,7 +881,8 @@ public abstract class RMQMessage implements Message, Cloneable {
         boolean redelivered = response.getEnvelope().isRedeliver();
         message.setJMSRedelivered(redelivered);
         if (redelivered) {
-            Number deliveryCount = (Number) response.getProps().getHeaders().get("x-delivery-count");
+            Map<String, Object> headers = response.getProps().getHeaders();
+			Number deliveryCount = headers != null ? (Number) headers.get("x-delivery-count") : null;
             if (deliveryCount == null) {
                 message.setIntProperty(JMS_X_DELIVERY_COUNT, 2);
             } else {

--- a/src/test/java/com/rabbitmq/jms/client/RMQMessageTest.java
+++ b/src/test/java/com/rabbitmq/jms/client/RMQMessageTest.java
@@ -93,6 +93,27 @@ class RMQMessageTest {
     }
 
     @Test
+    @DisplayName("RMQMessage::convertMessage - amqp message - JMSXDeliveryCount is set to default if no header is available")
+    void convertAMQPMessageWithRedeliverFlagAndNoHeaders() throws JMSException {
+
+        BasicProperties props = mock(BasicProperties.class);
+        Envelope envelope = mock(Envelope.class);
+
+        when(getResponse.getProps()).thenReturn(props);
+        when(props.getHeaders()).thenReturn(null);
+        when(getResponse.getEnvelope()).thenReturn(envelope);
+        when(envelope.isRedeliver()).thenReturn(true);
+
+        RMQDestination destination = new RMQDestination("dest", "exch", "key", "queue");
+        destination.setAmqp(true);
+
+        RMQMessage result = RMQMessage.convertMessage(session, destination, getResponse, consumer);
+
+        // if no header information (=null) is given, fall back to default delivery count
+        assertEquals(2, result.getIntProperty("JMSXDeliveryCount"));
+    }
+    
+    @Test
     @DisplayName("RMQMessage::convertMessage - amqp message - ensure JMS reply to is set to direct reply to")
     void convertAMQPMessageWithDirectReplyTo() throws JMSException {
 


### PR DESCRIPTION
This PR fixes #325 by checking first if the given headers of the RMQMessage is `null`.

Also added a test to verify.