### PR TITLE
Add authenticationMechanism property to RMQConnectionFactory

### DIFF
--- a/src/main/java/com/rabbitmq/jms/admin/RMQObjectFactory.java
+++ b/src/main/java/com/rabbitmq/jms/admin/RMQObjectFactory.java
@@ -11,6 +11,8 @@ import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import com.rabbitmq.jms.client.AuthenticationMechanism;
 import jakarta.jms.ConnectionFactory;
 import jakarta.jms.JMSException;
 import jakarta.jms.Queue;
@@ -224,6 +226,15 @@ public class RMQObjectFactory implements ObjectFactory {
         f.setDeclareReplyToDestination(getBooleanProperty(ref, environment, "declareReplyToDestination", true, true));
         f.setKeepTextMessageType(getBooleanProperty(ref, environment, "keepTextMessageType", true, false));
         f.setNackOnRollback(getBooleanProperty(ref, environment, "nackOnRollback", true, false));
+
+        String authenticationMechanismString = getStringProperty(ref, environment, "authenticationMechanism", true, null);
+        if (authenticationMechanismString != null) {
+            try {
+                f.setAuthenticationMechanism(AuthenticationMechanism.valueOf(authenticationMechanismString));
+            } catch (IllegalArgumentException e) {
+                LOGGER.warn("Failed to set AuthenticationMechanism on RMQConnectionFactory.", e);
+            }
+        }
         return f;
     }
 

--- a/src/main/java/com/rabbitmq/jms/client/AuthenticationMechanism.java
+++ b/src/main/java/com/rabbitmq/jms/client/AuthenticationMechanism.java
@@ -1,0 +1,21 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2013-2023 VMware, Inc. or its affiliates. All rights reserved.
+package com.rabbitmq.jms.client;
+
+/**
+ * Authentication mechanisms that the client can use to authenticate to the server.
+ */
+public enum AuthenticationMechanism {
+
+    /**
+     * Authentication mechanism corresponding to {@link com.rabbitmq.client.DefaultSaslConfig#PLAIN}
+     */
+    PLAIN,
+    /**
+     * Authentication mechanism corresponding to {@link com.rabbitmq.client.DefaultSaslConfig#EXTERNAL}
+     */
+    EXTERNAL;
+}

--- a/src/test/java/com/rabbitmq/jms/admin/RMQConnectionFactoryTest.java
+++ b/src/test/java/com/rabbitmq/jms/admin/RMQConnectionFactoryTest.java
@@ -10,6 +10,9 @@ import com.rabbitmq.client.Address;
 import com.rabbitmq.client.AddressResolver;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.DefaultSaslConfig;
+import com.rabbitmq.client.SaslConfig;
+import com.rabbitmq.jms.client.AuthenticationMechanism;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -26,6 +29,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,6 +55,7 @@ public class RMQConnectionFactoryTest {
         defaultProps.setProperty("virtualHost", "/");
         defaultProps.setProperty("cleanUpServerNamedQueuesForNonDurableTopicsOnSessionClose", "false");
         defaultProps.setProperty("declareReplyToDestination", "true");
+        defaultProps.setProperty("authenticationMechanism", AuthenticationMechanism.PLAIN.name());
     }
 
     private static Properties getProps(Reference ref) {
@@ -119,6 +124,7 @@ public class RMQConnectionFactoryTest {
         connFactory.setTerminationTimeout(1234567890123456789L);
         connFactory.setUsername("fred");
         connFactory.setVirtualHost("bill");
+        connFactory.setAuthenticationMechanism(AuthenticationMechanism.EXTERNAL);
 
         Reference ref = connFactory.getReference();
         Properties newProps = getProps(ref);
@@ -126,6 +132,7 @@ public class RMQConnectionFactoryTest {
         assertEquals("amqps://fred:my-password@sillyHost:42/bill", newProps.getProperty("uri"), "Not the correct uri");
         assertEquals("52", newProps.getProperty("queueBrowserReadMax"), "Not the correct queueBrowserReadMax");
         assertEquals("62", newProps.getProperty("onMessageTimeoutMs"), "Not the correct onMessageTimeoutMs");
+        assertEquals(AuthenticationMechanism.EXTERNAL.name(), newProps.getProperty("authenticationMechanism"), "Not the correct authenticationMechanism");
     }
 
     @Test
@@ -144,6 +151,7 @@ public class RMQConnectionFactoryTest {
         connFactory.setVirtualHost("bill");
         connFactory.setCleanUpServerNamedQueuesForNonDurableTopicsOnSessionClose(true);
         connFactory.setDeclareReplyToDestination(false);
+        connFactory.setAuthenticationMechanism(AuthenticationMechanism.EXTERNAL);
 
         Reference ref = connFactory.getReference();
 
@@ -165,9 +173,9 @@ public class RMQConnectionFactoryTest {
         assertEquals("bill", newFactory.getVirtualHost(), "Not the correct virtualHost");
         assertTrue(newFactory.isCleanUpServerNamedQueuesForNonDurableTopicsOnSessionClose());
 
-        Field declareReplyToDestinationField = RMQConnectionFactory.class.getDeclaredField("declareReplyToDestination");
-        declareReplyToDestinationField.setAccessible(true);
-        assertFalse((Boolean) declareReplyToDestinationField.get(newFactory));
+        assertFalse((Boolean) getRMQConnectionFactoryFieldValue(newFactory, "declareReplyToDestination"));
+
+        assertEquals(AuthenticationMechanism.EXTERNAL, getRMQConnectionFactoryFieldValue(newFactory, "authenticationMechanism"));
     }
 
     @Test
@@ -184,6 +192,7 @@ public class RMQConnectionFactoryTest {
         environment.put("terminationTimeout", 1234567890123456789L);
         environment.put("username", "fred");
         environment.put("virtualHost", "bill");
+        environment.put("authenticationMechanism", AuthenticationMechanism.EXTERNAL);
 
         RMQConnectionFactory newFactory = (RMQConnectionFactory) new RMQObjectFactory().createConnectionFactory(null, environment, new CompositeName("newOne"));
 
@@ -199,6 +208,8 @@ public class RMQConnectionFactoryTest {
 
         assertEquals("fred", newFactory.getUsername(), "Not the correct username");
         assertEquals("bill", newFactory.getVirtualHost(), "Not the correct virtualHost");
+
+        assertEquals(AuthenticationMechanism.EXTERNAL, getRMQConnectionFactoryFieldValue(newFactory, "authenticationMechanism"));
     }
 
     @Test
@@ -217,6 +228,7 @@ public class RMQConnectionFactoryTest {
         addStringRefProperty(ref, "terminationTimeout", "1234567890123456789");
         addStringRefProperty(ref, "username", "fred");
         addStringRefProperty(ref, "virtualHost", "bill");
+        addStringRefProperty(ref, "authenticationMechanism", AuthenticationMechanism.EXTERNAL.name());
 
         RMQConnectionFactory newFactory = (RMQConnectionFactory) new RMQObjectFactory().createConnectionFactory(ref, new Hashtable<Object, Object>(), new CompositeName("newOne"));
 
@@ -233,6 +245,14 @@ public class RMQConnectionFactoryTest {
         assertEquals("bill", newFactory.getVirtualHost(), "Not the correct virtualHost");
 
         assertEquals("amqps://fred:my-password@sillyHost:42/bill", newFactory.getUri());
+
+        assertEquals(AuthenticationMechanism.EXTERNAL, getRMQConnectionFactoryFieldValue(newFactory, "authenticationMechanism"));
+    }
+
+    private <T> T getRMQConnectionFactoryFieldValue(RMQConnectionFactory factory, String fieldName) throws Exception {
+        Field field = RMQConnectionFactory.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return (T) field.get(factory);
     }
 
     TestRmqConnectionFactory rmqCf;
@@ -305,6 +325,15 @@ public class RMQConnectionFactoryTest {
         assertEquals(1, callCount.get());
         rmqCf.createConnection();
         assertEquals(2, callCount.get());
+    }
+
+    @Test
+    public void saslConfigIsSet() throws Exception {
+        AtomicReference<SaslConfig> saslConfigRef = new AtomicReference<>();
+        rmqCf.setAuthenticationMechanism(AuthenticationMechanism.EXTERNAL);
+        rmqCf.setAmqpConnectionFactoryPostProcessor(cf -> saslConfigRef.set(cf.getSaslConfig()));
+        rmqCf.createConnection();
+        assertEquals(DefaultSaslConfig.EXTERNAL, saslConfigRef.get());
     }
 
     @Test


### PR DESCRIPTION
Adds feature described in #326 

Instead of exposing `setSaslConfig(SaslConfig)` directly, `AuthenticationMechanism` was introduced in order to keep the `Serializable` and `Referenceable` contracts of `RMQConnectionFactory`.