### PR TITLE
Add customizer callback for AMQP connections

### DIFF
--- a/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
@@ -164,6 +164,13 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
     private Consumer<com.rabbitmq.client.ConnectionFactory> amqpConnectionFactoryPostProcessor = new NoOpSerializableConsumer<>();
 
     /**
+     * For post-processing the created {@link com.rabbitmq.client.Connection}
+     *
+     * @since 2.10.0
+     */
+    private Consumer<com.rabbitmq.client.Connection> amqpConnectionPostProcessor = new NoOpSerializableConsumer<>();
+
+    /**
      * Callback before sending a message.
      *
      * @since 1.11.0
@@ -312,6 +319,10 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
         }
 
         com.rabbitmq.client.Connection rabbitConnection = instantiateNodeConnection(cf, connectionCreator);
+
+        if (this.amqpConnectionPostProcessor != null) {
+            this.amqpConnectionPostProcessor.accept(rabbitConnection);
+        }
 
         ReceivingContextConsumer rcc;
         if (this.declareReplyToDestination) {
@@ -1007,7 +1018,7 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
     public void setMetricsCollector(MetricsCollector metricsCollector) {
         this.metricsCollector = metricsCollector;
     }
-    
+
     public List<String> getUris() {
         return this.uris.stream().map(uri -> uri.toString()).collect(Collectors.toList());
     }
@@ -1024,6 +1035,32 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
      */
     public void setAmqpConnectionFactoryPostProcessor(Consumer<com.rabbitmq.client.ConnectionFactory> amqpConnectionFactoryPostProcessor) {
         this.amqpConnectionFactoryPostProcessor = amqpConnectionFactoryPostProcessor;
+    }
+
+
+    /**
+     * Sets a post-processor for the created {@link com.rabbitmq.client.Connection}.
+     * <p>
+     * The post-processor is called after the {@link com.rabbitmq.client.Connection} is created and established. This callback
+     * can be used to customize the {@link com.rabbitmq.client.Connection} e.g. adding a {@link com.rabbitmq.client.BlockedListener}
+     * that emits a log message when this connection gets blocked:
+     * <pre>
+     * {@code
+     * RMQConnectionFactory factory = new RMQConnectionFactory();
+     * // ...
+     * factory.setAmqpConnectionPostProcessor(connection ->
+     *                 connection.addBlockedListener(
+     *                         reason -> log.warn("Connection blocked: {}", reason),
+     *                         () -> log.info("Connection unblocked"))
+     *         );
+     * }
+     * </pre>
+     *
+     * @param amqpConnectionPostProcessor callback that processes the AMQP connections after they are established
+     * @since 2.10.0
+     */
+    public void setAmqpConnectionPostProcessor(Consumer<com.rabbitmq.client.Connection> amqpConnectionPostProcessor) {
+        this.amqpConnectionPostProcessor = amqpConnectionPostProcessor;
     }
 
     /**

--- a/src/test/java/com/rabbitmq/jms/admin/RMQConnectionFactoryTest.java
+++ b/src/test/java/com/rabbitmq/jms/admin/RMQConnectionFactoryTest.java
@@ -319,13 +319,24 @@ public class RMQConnectionFactoryTest {
         assertEquals(10000, passedInAddressResolver.getAddresses().get(1).getPort());
     }
 
-    @Test public void amqpConnectionFactoryIsCalled() throws Exception {
+    @Test
+    public void amqpConnectionFactoryIsCalled() throws Exception {
         AtomicInteger callCount = new AtomicInteger(0);
         rmqCf.setAmqpConnectionFactoryPostProcessor(cf -> callCount.incrementAndGet());
         rmqCf.createConnection();
         assertEquals(1, callCount.get());
         rmqCf.createConnection();
         assertEquals(2, callCount.get());
+    }
+
+    @Test
+    public void shouldApplyConnectionCustomizer() throws Exception {
+        AtomicInteger callCount = new AtomicInteger(0);
+        rmqCf.setAmqpConnectionPostProcessor(connection -> callCount.incrementAndGet());
+        rmqCf.createConnection();
+        assertEquals(1, callCount.get(), "Connection customizer calls");
+        rmqCf.createConnection();
+        assertEquals(2, callCount.get(), "Connection customizer calls");
     }
 
     @Test


### PR DESCRIPTION
Follow-up of the discussion [Make it easier to detect blocked connections #1415 ](https://github.com/rabbitmq/rabbitmq-java-client/discussions/1415) in [rabbitmq-java-client](https://github.com/rabbitmq/rabbitmq-java-client) this PR adds a customizer callback for `com.rabbitmq.client.Connection`(s) akin to the customizer callback for `com.rabbitmq.client.ConnectionFactory`



