### PR TITLE
feature: Extract destinations constants to singleton

### DIFF
--- a/src/main/java/com/rabbitmq/jms/admin/RMQDefaultDestinations.java
+++ b/src/main/java/com/rabbitmq/jms/admin/RMQDefaultDestinations.java
@@ -1,0 +1,122 @@
+package com.rabbitmq.jms.admin;
+
+/**
+ * Default destinations for RabbitMQ JMS.
+ */
+public class RMQDefaultDestinations {
+    private static final String JMS_DURABLE_TOPIC_EXCHANGE_NAME = "jms.durable.topic";  // fixed topic exchange in RabbitMQ for jms traffic
+    private static final String JMS_TEMP_TOPIC_EXCHANGE_NAME = "jms.temp.topic";        // fixed topic exchange in RabbitMQ for jms traffic
+
+    private static final String JMS_DURABLE_QUEUE_EXCHANGE_NAME = "jms.durable.queues"; // fixed queue exchange in RabbitMQ for jms traffic
+    private static final String JMS_TEMP_QUEUE_EXCHANGE_NAME = "jms.temp.queues";       // fixed queue exchange in RabbitMQ for jms traffic
+
+    private static final String JMS_CONSUMER_QUEUE_NAME_PREFIX = "jms-cons-";
+    private static final String JMS_DURABLE_TOPIC_SELECTOR_EXCHANGE_PREFIX = "jms-dutop-slx-";
+    private static final String JMS_NON_DURABLE_TOPIC_SELECTOR_EXCHANGE_PREFIX = "jms-ndtop-slx-";
+
+    private static final String JMS_TEMP_QUEUE_PREFIF = "jms-temp-queue-";
+    private static final String JMS_TEMP_TOPIC_PREFIF = "jms-temp-topic-";
+
+    private String durableTopicExchangeName;
+    private String tempTopicExchangeName;
+    private String durableQueueExchangeName;
+    private String tempQueueExchangeName;
+    private String consumerQueueNamePrefix;
+    private String durableTopicSelectorExchangePrefix;
+    private String nonDurableTopicSelectorExchangePrefix;
+    private String tempQueuePrefix;
+    private String tempTopicPrefix;
+
+    private static RMQDefaultDestinations instance;
+
+    private RMQDefaultDestinations() {
+        this.durableTopicExchangeName = JMS_DURABLE_TOPIC_EXCHANGE_NAME;
+        this.tempTopicExchangeName = JMS_TEMP_TOPIC_EXCHANGE_NAME;
+        this.durableQueueExchangeName = JMS_DURABLE_QUEUE_EXCHANGE_NAME;
+        this.tempQueueExchangeName = JMS_TEMP_QUEUE_EXCHANGE_NAME;
+        this.consumerQueueNamePrefix = JMS_CONSUMER_QUEUE_NAME_PREFIX;
+        this.durableTopicSelectorExchangePrefix = JMS_DURABLE_TOPIC_SELECTOR_EXCHANGE_PREFIX;
+        this.nonDurableTopicSelectorExchangePrefix = JMS_NON_DURABLE_TOPIC_SELECTOR_EXCHANGE_PREFIX;
+        this.tempQueuePrefix = JMS_TEMP_QUEUE_PREFIF;
+        this.tempTopicPrefix = JMS_TEMP_TOPIC_PREFIF;
+    }
+
+    public static RMQDefaultDestinations getInstance() {
+        if (instance == null) {
+            instance = new RMQDefaultDestinations();
+        }
+        return instance;
+    }
+
+    public String getDurableTopicExchangeName() {
+        return durableTopicExchangeName;
+    }
+
+    public void setDurableTopicExchangeName(String durableTopicExchangeName) {
+        this.durableTopicExchangeName = durableTopicExchangeName;
+    }
+
+    public String getTempTopicExchangeName() {
+        return tempTopicExchangeName;
+    }
+
+    public void setTempTopicExchangeName(String tempTopicExchangeName) {
+        this.tempTopicExchangeName = tempTopicExchangeName;
+    }
+
+    public String getDurableQueueExchangeName() {
+        return durableQueueExchangeName;
+    }
+
+    public void setDurableQueueExchangeName(String durableQueueExchangeName) {
+        this.durableQueueExchangeName = durableQueueExchangeName;
+    }
+
+    public String getTempQueueExchangeName() {
+        return tempQueueExchangeName;
+    }
+
+    public void setTempQueueExchangeName(String tempQueueExchangeName) {
+        this.tempQueueExchangeName = tempQueueExchangeName;
+    }
+
+    public String getConsumerQueueNamePrefix() {
+        return consumerQueueNamePrefix;
+    }
+
+    public void setConsumerQueueNamePrefix(String consumerQueueNamePrefix) {
+        this.consumerQueueNamePrefix = consumerQueueNamePrefix;
+    }
+
+    public String getDurableTopicSelectorExchangePrefix() {
+        return durableTopicSelectorExchangePrefix;
+    }
+
+    public void setDurableTopicSelectorExchangePrefix(String durableTopicSelectorExchangePrefix) {
+        this.durableTopicSelectorExchangePrefix = durableTopicSelectorExchangePrefix;
+    }
+
+    public String getNonDurableTopicSelectorExchangePrefix() {
+        return nonDurableTopicSelectorExchangePrefix;
+    }
+
+    public void setNonDurableTopicSelectorExchangePrefix(String nonDurableTopicSelectorExchangePrefix) {
+        this.nonDurableTopicSelectorExchangePrefix = nonDurableTopicSelectorExchangePrefix;
+    }
+
+    public String getTempQueuePrefix() {
+        return tempQueuePrefix;
+    }
+
+    public void setTempQueuePrefix(String tempQueuePrefix) {
+        this.tempQueuePrefix = tempQueuePrefix;
+    }
+
+    public String getTempTopicPrefix() {
+        return tempTopicPrefix;
+    }
+
+    public void setTempTopicPrefix(String tempTopicPrefix) {
+        this.tempTopicPrefix = tempTopicPrefix;
+    }
+}

--- a/src/main/java/com/rabbitmq/jms/admin/RMQDestination.java
+++ b/src/main/java/com/rabbitmq/jms/admin/RMQDestination.java
@@ -30,14 +30,12 @@ public class RMQDestination implements Queue, Topic, Destination, Referenceable,
 
     private static final String RABBITMQ_AMQ_TOPIC_EXCHANGE_NAME = "amq.topic";
     private static final String RABBITMQ_AMQ_TOPIC_EXCHANGE_TYPE = "topic";             // standard topic exchange type in RabbitMQ
-    private static final String JMS_DURABLE_TOPIC_EXCHANGE_NAME = "jms.durable.topic";  // fixed topic exchange in RabbitMQ for jms traffic
-    private static final String JMS_TEMP_TOPIC_EXCHANGE_NAME = "jms.temp.topic";        // fixed topic exchange in RabbitMQ for jms traffic
 
     private static final String RABBITMQ_UNNAMED_EXCHANGE = "";
     private static final String RABBITMQ_AMQ_DIRECT_EXCHANGE_NAME = "amq.direct";
     private static final String RABBITMQ_AMQ_DIRECT_EXCHANGE_TYPE = "direct";           // standard direct exchange type in RabbitMQ
-    private static final String JMS_DURABLE_QUEUE_EXCHANGE_NAME = "jms.durable.queues"; // fixed queue exchange in RabbitMQ for jms traffic
-    private static final String JMS_TEMP_QUEUE_EXCHANGE_NAME = "jms.temp.queues";       // fixed queue exchange in RabbitMQ for jms traffic
+
+    private static final RMQDefaultDestinations DEFAULT_DESTINATIONS = RMQDefaultDestinations.getInstance();
 
     // Would like all these to be final, but we need to allow set them
     private String destinationName;
@@ -83,10 +81,10 @@ public class RMQDestination implements Queue, Topic, Destination, Referenceable,
     }
 
     private static String queueOrTopicExchangeName(boolean isQueue, boolean isTemporary) {
-        if (isQueue & isTemporary)              return JMS_TEMP_QUEUE_EXCHANGE_NAME;
-        else if (isQueue & !isTemporary)        return JMS_DURABLE_QUEUE_EXCHANGE_NAME;
-        else if (!isQueue & isTemporary)        return JMS_TEMP_TOPIC_EXCHANGE_NAME;
-        else /* if (!isQueue & !isTemporary) */ return JMS_DURABLE_TOPIC_EXCHANGE_NAME;
+        if (isQueue & isTemporary)              return DEFAULT_DESTINATIONS.getTempQueueExchangeName();
+        else if (isQueue & !isTemporary)        return DEFAULT_DESTINATIONS.getDurableQueueExchangeName();
+        else if (!isQueue & isTemporary)        return DEFAULT_DESTINATIONS.getTempTopicExchangeName();
+        else /* if (!isQueue & !isTemporary) */ return DEFAULT_DESTINATIONS.getDurableTopicExchangeName();
     }
 
     private static String queueOrTopicExchangeType(boolean isQueue) {

--- a/src/main/java/com/rabbitmq/jms/client/RMQSession.java
+++ b/src/main/java/com/rabbitmq/jms/client/RMQSession.java
@@ -5,6 +5,7 @@
 // Copyright (c) 2013-2023 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 package com.rabbitmq.jms.client;
 
+import com.rabbitmq.jms.admin.RMQDefaultDestinations;
 import com.rabbitmq.jms.client.Subscription.Context;
 import com.rabbitmq.jms.client.Subscription.PostAction;
 import java.io.IOException;
@@ -804,7 +805,7 @@ public class RMQSession implements Session, QueueSession, TopicSession {
     }
 
     private static String generateJmsConsumerQueueName() {
-       return Util.generateUUID("jms-cons-");
+       return Util.generateUUID(RMQDefaultDestinations.getInstance().getConsumerQueueNamePrefix());
     }
 
     /**
@@ -823,7 +824,7 @@ public class RMQSession implements Session, QueueSession, TopicSession {
 
     private String getDurableTopicSelectorExchange() throws IOException {
         if (this.durableTopicSelectorExchange==null) {
-            this.durableTopicSelectorExchange = Util.generateUUID("jms-dutop-slx-");
+            this.durableTopicSelectorExchange = Util.generateUUID(RMQDefaultDestinations.getInstance().getDurableTopicSelectorExchangePrefix());
         }
         this.channel.exchangeDeclare(this.durableTopicSelectorExchange, JMS_TOPIC_SELECTOR_EXCHANGE_TYPE, true, true, RJMS_SELECTOR_EXCHANGE_ARGS);
         return this.durableTopicSelectorExchange;
@@ -831,7 +832,7 @@ public class RMQSession implements Session, QueueSession, TopicSession {
 
     private String getNonDurableTopicSelectorExchange() throws IOException {
         if (this.nonDurableTopicSelectorExchange==null) {
-            this.nonDurableTopicSelectorExchange = Util.generateUUID("jms-ndtop-slx-");
+            this.nonDurableTopicSelectorExchange = Util.generateUUID(RMQDefaultDestinations.getInstance().getNonDurableTopicSelectorExchangePrefix());
         }
         this.channel.exchangeDeclare(this.nonDurableTopicSelectorExchange, JMS_TOPIC_SELECTOR_EXCHANGE_TYPE, false, true, RJMS_SELECTOR_EXCHANGE_ARGS);
         return this.nonDurableTopicSelectorExchange;
@@ -1124,7 +1125,7 @@ public class RMQSession implements Session, QueueSession, TopicSession {
     @Override
     public TemporaryQueue createTemporaryQueue() throws JMSException {
         illegalStateExceptionIfClosed();
-        return new RMQDestination(Util.generateUUID("jms-temp-queue-"), true, true);
+        return new RMQDestination(Util.generateUUID(RMQDefaultDestinations.getInstance().getTempQueuePrefix()), true, true);
     }
 
     /**
@@ -1133,7 +1134,7 @@ public class RMQSession implements Session, QueueSession, TopicSession {
     @Override
     public TemporaryTopic createTemporaryTopic() throws JMSException {
         illegalStateExceptionIfClosed();
-        return new RMQDestination(Util.generateUUID("jms-temp-topic-"), false, true);
+        return new RMQDestination(Util.generateUUID(RMQDefaultDestinations.getInstance().getTempTopicPrefix()), false, true);
     }
 
     /**


### PR DESCRIPTION
We want yo migrate from another JMS implentations to RabbitMQ, and we would like to use this library. But we have some security constraints related to permissions and exchanges and queues naming. 

With this PR, we have extracted some hard-coded constants to a class using Singleton pattern. By default the behavior is the same as before, but with this change it is possible to change:

- JMS_DURABLE_TOPIC_EXCHANGE_NAME = "jms.durable.topic"; 
- JMS_TEMP_TOPIC_EXCHANGE_NAME = "jms.temp.topic"; 
- JMS_DURABLE_QUEUE_EXCHANGE_NAME = "jms.durable.queues";
- JMS_TEMP_QUEUE_EXCHANGE_NAME = "jms.temp.queues";  
- JMS_CONSUMER_QUEUE_NAME_PREFIX = "jms-cons-";
- JMS_DURABLE_TOPIC_SELECTOR_EXCHANGE_PREFIX = "jms-dutop-slx-";
- JMS_NON_DURABLE_TOPIC_SELECTOR_EXCHANGE_PREFIX = "jms-ndtop-slx-";
- JMS_TEMP_QUEUE_PREFIF = "jms-temp-queue-";
 - JMS_TEMP_TOPIC_PREFIF = "jms-temp-topic-";  