### PR TITLE
Remove redundant hostname verification activation

### DIFF
--- a/ci/start-broker.sh
+++ b/ci/start-broker.sh
@@ -36,7 +36,7 @@ echo "Running RabbitMQ ${RABBITMQ_IMAGE}"
 
 docker rm -f rabbitmq 2>/dev/null || echo "rabbitmq was not running"
 docker run -d --name rabbitmq \
-    --network host \
+    -p 5671:5671 -p 5672:5672 \
     -v "${PWD}"/rabbitmq-configuration:/etc/rabbitmq \
     -v "${PWD}"/ci/rabbitmq_delayed_message_exchange-"${DELAYED_MESSAGE_EXCHANGE_PLUGIN_VERSION}".ez:/opt/rabbitmq/plugins/rabbitmq_delayed_message_exchange-"${DELAYED_MESSAGE_EXCHANGE_PLUGIN_VERSION}".ez \
     "${RABBITMQ_IMAGE}"

--- a/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
@@ -502,23 +502,26 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
     }
 
     private void maybeEnableTLS(com.rabbitmq.client.ConnectionFactory factory) {
-        if (this.ssl)
-            try {
-                if(this.useDefaultSslContext) {
-                    factory.useSslProtocol(SSLContext.getDefault());
-                } else {
-                    if (this.sslContext != null) {
-                        factory.useSslProtocol(this.sslContext);
-                    } else if (this.tlsProtocol != null) {
-                        factory.useSslProtocol(this.tlsProtocol);
-                    } else {
-                        factory.useSslProtocol();
-                    }
-                }
-            } catch (Exception e) {
-                this.logger.warn("Could not set SSL protocol on connection factory, {}. SSL set off.", this, e);
-                this.ssl = false;
+      if (this.ssl) {
+        try {
+          if (this.useDefaultSslContext) {
+            factory.useSslProtocol(SSLContext.getDefault());
+          } else {
+            if (this.sslContext != null) {
+            System.out.println("passe maybe");
+              factory.useSslProtocol(this.sslContext);
+            } else if (this.tlsProtocol != null) {
+              factory.useSslProtocol(this.tlsProtocol);
+            } else {
+              factory.useSslProtocol();
             }
+          }
+        } catch (Exception e) {
+          this.logger.warn(
+              "Could not set SSL protocol on connection factory, {}. SSL set off.", this, e);
+          this.ssl = false;
+        }
+      }
     }
 
     private void maybeEnableHostnameVerification() {

--- a/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
@@ -317,7 +317,7 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
         com.rabbitmq.client.ConnectionFactory cf = createConnectionFactory();
         maybeEnableTLS(cf);
         setRabbitUri(logger, this, cf, getUri());
-        maybeEnableHostnameVerification(cf);
+        maybeEnableHostnameVerification();
         cf.setMetricsCollector(this.metricsCollector);
         setSaslConfig(cf, authenticationMechanism);
 
@@ -521,13 +521,10 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
             }
     }
 
-    private void maybeEnableHostnameVerification(com.rabbitmq.client.ConnectionFactory factory) {
-        if (hostnameVerification) {
-            if (this.ssl) {
-                factory.enableHostnameVerification();
-            } else {
-                logger.warn("Hostname verification enabled, but not TLS, please enable TLS too.");
-            }
+    private void maybeEnableHostnameVerification() {
+        // hostname verification is enabled automatically with SSL, no need to enable it explicitly
+        if (hostnameVerification && !this.ssl) {
+            logger.warn("Hostname verification enabled, but not TLS, please enable TLS too.");
         }
     }
 

--- a/src/test/java/com/rabbitmq/integration/tests/RabbitAPIConnectionFactory.java
+++ b/src/test/java/com/rabbitmq/integration/tests/RabbitAPIConnectionFactory.java
@@ -11,8 +11,6 @@ import jakarta.jms.JMSException;
 
 import com.rabbitmq.jms.admin.RMQConnectionFactory;
 
-import java.security.NoSuchAlgorithmException;
-
 /**
  * Connection factory for use in integration tests.
  */
@@ -22,8 +20,6 @@ public class RabbitAPIConnectionFactory extends AbstractTestConnectionFactory {
     private static final int RABBIT_TLS_PORT = 5671;
     private final boolean testssl;
     private int qbrMax;
-
-    public RabbitAPIConnectionFactory() { this(false); }
 
     public RabbitAPIConnectionFactory(boolean testssl) { this(testssl, 0); }
 
@@ -46,11 +42,13 @@ public class RabbitAPIConnectionFactory extends AbstractTestConnectionFactory {
             }
         };
         if (testssl) {
-            try {
-                rmqCF.useSslProtocol();
-            } catch (NoSuchAlgorithmException e) {
-                throw new RuntimeException(e);
-            }
+            rmqCF.setAmqpConnectionFactoryPostProcessor(cf -> {
+                try {
+                    cf.useTlsWithNoVerification();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
         }
         rmqCF.setQueueBrowserReadMax(qbrMax);
         return rmqCF;

--- a/src/test/java/com/rabbitmq/integration/tests/RabbitAPIConnectionFactory.java
+++ b/src/test/java/com/rabbitmq/integration/tests/RabbitAPIConnectionFactory.java
@@ -11,6 +11,8 @@ import jakarta.jms.JMSException;
 
 import com.rabbitmq.jms.admin.RMQConnectionFactory;
 
+import java.util.function.Consumer;
+
 /**
  * Connection factory for use in integration tests.
  */
@@ -29,6 +31,16 @@ public class RabbitAPIConnectionFactory extends AbstractTestConnectionFactory {
 
     @Override
     public ConnectionFactory getConnectionFactory() {
+        Consumer<com.rabbitmq.client.ConnectionFactory> rmqCfConsumer =
+            testssl
+                ? cf -> {
+                try {
+                    cf.useTlsWithNoVerification();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+                : cf -> {};
         RMQConnectionFactory rmqCF = new RMQConnectionFactory() {
             private static final long serialVersionUID = 1L;
             @Override
@@ -40,16 +52,14 @@ public class RabbitAPIConnectionFactory extends AbstractTestConnectionFactory {
                 }
                 return super.createConnection(userName, password);
             }
+
+            @Override
+            protected com.rabbitmq.client.ConnectionFactory createConnectionFactory() {
+                com.rabbitmq.client.ConnectionFactory cf =  super.createConnectionFactory();
+                rmqCfConsumer.accept(cf);
+                return cf;
+            }
         };
-        if (testssl) {
-            rmqCF.setAmqpConnectionFactoryPostProcessor(cf -> {
-                try {
-                    cf.useTlsWithNoVerification();
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-            });
-        }
         rmqCF.setQueueBrowserReadMax(qbrMax);
         return rmqCF;
     }

--- a/src/test/java/com/rabbitmq/integration/tests/SslContextIT.java
+++ b/src/test/java/com/rabbitmq/integration/tests/SslContextIT.java
@@ -90,12 +90,12 @@ public class SslContextIT {
         private final AtomicInteger checkServerTrustedCallCount = new AtomicInteger();
 
         @Override
-        public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+        public void checkClientTrusted(X509Certificate[] x509Certificates, String s) {
 
         }
 
         @Override
-        public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
+        public void checkServerTrusted(X509Certificate[] x509Certificates, String s) {
             checkServerTrustedCallCount.incrementAndGet();
         }
 


### PR DESCRIPTION
Now it is enabled by default in AMQP client.