### PR TITLE
Add a RMQConnectionFactory constructor that takes an URI

### DIFF
--- a/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
+++ b/src/main/java/com/rabbitmq/jms/admin/RMQConnectionFactory.java
@@ -272,6 +272,17 @@ public class RMQConnectionFactory implements ConnectionFactory, Referenceable, S
      */
     private NamingStrategy namingStrategy = NamingStrategy.DEFAULT;
 
+    public RMQConnectionFactory() {
+    }
+
+    public RMQConnectionFactory(String uri) {
+        try {
+            setUri(uri);
+        } catch (JMSException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
This is needed for Appia middleware which does not support setting properties on the connection factory.

PS: We will contribute the same change to the JMS 2.x branch.